### PR TITLE
feat: optional persona-initiated photo sending via --photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ It can also become a place to practice:
 - 🔎 Can auto-generate personas from a **name, link, or short prompt**
 - 🌐 Supports remote persona compilation and hosting workflows
 - 📊 Exposes a live ECC trace/debug panel during runs
+- 📷 Optional persona-initiated photo sending via `--photos` (OpenAI image gen, capped at 5 per session)
 
 ---
 

--- a/src/girlfriend_generator/app.py
+++ b/src/girlfriend_generator/app.py
@@ -27,6 +27,7 @@ from .personas import load_persona
 from .providers import ProviderConfig, build_provider
 from .session_io import export_session, load_session_snapshot
 from .music import build_music_player
+from .photo import PhotoState, generate_photo, open_in_default_app, render_photo_message
 from .voice import build_voice_input, build_voice_output
 
 
@@ -42,6 +43,8 @@ class AppConfig:
     performance_mode: str = "turbo"
     voice_output: bool = False
     voice_input_command: str | None = None
+    photos_enabled: bool = False
+    photos_auto_open: bool = True
     show_trace: bool = True
     input_poll_active_seconds: float = 0.03
     input_poll_idle_seconds: float = 0.08
@@ -58,6 +61,7 @@ class PendingDelivery:
     trace_note: str
     typing_starts_at: float | None = None  # when to show "typing..." indicator
     burst_queue: list[str] = field(default_factory=list)  # follow-up burst messages
+    photo_prompt: str = ""  # if set, generate a photo after delivery (opt-in via --photos)
 
 
 class BackgroundJob:
@@ -180,6 +184,34 @@ def _drain_pending_stdin() -> None:
 
 
 
+def _spawn_photo_job(
+    *,
+    prompt: str,
+    persona: Persona,
+    session: ConversationSession,
+    photo_state: PhotoState,
+) -> None:
+    """Run image generation in a fire-and-forget thread; emit a system message on result."""
+    photo_state.sent_count += 1
+    out_dir = photo_state.session_photos_dir or Path("sessions/photos")
+
+    def _runner() -> None:
+        try:
+            path = generate_photo(prompt, persona.name, out_dir)
+        except Exception as exc:
+            session.add_system_message(f"📷 사진 생성 실패: {exc}")
+            photo_state.sent_count = max(0, photo_state.sent_count - 1)
+            return
+        session.add_system_message(
+            render_photo_message(path, prompt, photo_state.remaining())
+        )
+        if photo_state.auto_open:
+            open_in_default_app(path)
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+
+
 def run_chat_app(config: AppConfig) -> int:
     console = Console()
     if not _supports_interactive_chat():
@@ -242,6 +274,11 @@ def run_chat_app(config: AppConfig) -> int:
     last_render_key: tuple[Any, ...] | None = None
     scroll_offset = 0  # 0 = latest messages, positive = scrolled up
     voice_output_enabled = config.voice_output and voice_output.name != "off"
+    photo_state = PhotoState(
+        enabled=config.photos_enabled and config.provider_name == "openai",
+        session_photos_dir=config.session_dir / "photos",
+        auto_open=config.photos_auto_open,
+    )
 
     try:
         with RawKeyboard() as keyboard, Live(
@@ -291,6 +328,18 @@ def run_chat_app(config: AppConfig) -> int:
                     status_line = _friendly_activity_status(pending_delivery.kind)
                     if voice_output_enabled:
                         voice_output.speak(delivered_text)
+                    # Photo: persona attached an image to this reply
+                    if (
+                        pending_delivery.photo_prompt
+                        and photo_state.can_send()
+                        and pending_delivery.kind == "reply"
+                    ):
+                        _spawn_photo_job(
+                            prompt=pending_delivery.photo_prompt,
+                            persona=persona,
+                            session=session,
+                            photo_state=photo_state,
+                        )
                     # Handle burst follow-ups: queue them as additional deliveries
                     if pending_delivery.burst_queue:
                         next_text = pending_delivery.burst_queue[0]
@@ -408,6 +457,7 @@ def run_chat_app(config: AppConfig) -> int:
                         voice_output_enabled=voice_output_enabled,
                         show_trace=show_trace, session_dir=config.session_dir,
                         music_player=music_player,
+                        photo_state=photo_state,
                     )
                     draft = outcome["draft"]
                     scroll_offset = 0 if outcome.get("sent") else scroll_offset
@@ -1246,6 +1296,7 @@ def _finish_job(
             typing_starts_at=now + seen_delay,
             trace_note=reply.trace_note + trace_extra,
             burst_queue=reply.burst_messages if reply.should_burst else [],
+            photo_prompt=reply.photo_prompt,
         )
         return None, delivery, "답장을 준비 중이에요."
 
@@ -1266,6 +1317,7 @@ def _handle_key(
     show_trace: bool,
     session_dir: Path,
     music_player: Any = None,
+    photo_state: PhotoState | None = None,
 ) -> dict[str, Any]:
     # Scroll: arrow keys when draft is empty, also [ and ]
     is_scroll_up = key in ("\x1b[A", "\x1b[5~", "[")
@@ -1367,6 +1419,8 @@ def _handle_key(
         memory = "; ".join(session.memory_notes[-5:])
         from .i18n import get_language
         lang = get_language()
+        photos_enabled = bool(photo_state and photo_state.can_send())
+        photos_remaining = photo_state.remaining() if photo_state else 0
         job = BackgroundJob(
             "reply",
             lambda: provider.generate_reply(
@@ -1377,6 +1431,8 @@ def _handle_key(
                 difficulty=persona.difficulty,
                 language=lang,
                 special_mode=persona.special_mode,
+                photos_enabled=photos_enabled,
+                photos_remaining=photos_remaining,
                 **session.prompt_context(),
             ),
         )

--- a/src/girlfriend_generator/cli.py
+++ b/src/girlfriend_generator/cli.py
@@ -134,6 +134,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Command that prints a voice transcript to stdout.",
     )
     parser.add_argument(
+        "--photos",
+        action="store_true",
+        help=(
+            "Allow the persona to autonomously send photos via OpenAI image generation. "
+            "Off by default (image API costs apply). Capped at 5 photos per session. "
+            "OpenAI provider only."
+        ),
+    )
+    parser.add_argument(
+        "--photos-no-open",
+        action="store_true",
+        help="With --photos, skip auto-opening images in the OS default viewer.",
+    )
+    parser.add_argument(
         "--server-base-url",
         help="Base URL for the remote persona/runtime server.",
     )
@@ -517,6 +531,8 @@ def _launch_chat(
         performance_mode=args.performance,
         voice_output=args.voice_output,
         voice_input_command=args.voice_input_command,
+        photos_enabled=args.photos,
+        photos_auto_open=not args.photos_no_open,
         session_dir=resolve_session_dir(args.session_dir),
         export_on_exit=not args.no_export_on_exit,
         show_trace=not args.no_trace,

--- a/src/girlfriend_generator/models.py
+++ b/src/girlfriend_generator/models.py
@@ -143,6 +143,7 @@ class ProviderReply:
     should_burst: bool = False
     burst_messages: list[str] = field(default_factory=list)
     next_proactive_seconds: int | None = None
+    photo_prompt: str = ""
 
 
 @dataclass(slots=True)

--- a/src/girlfriend_generator/photo.py
+++ b/src/girlfriend_generator/photo.py
@@ -1,0 +1,115 @@
+"""Persona-initiated photo sending (duct-tape implementation).
+
+The persona's reply JSON can include a `photo_prompt` string. When the user
+opted in via `--photos` and the OpenAI provider is in use, we generate the
+image with `gpt-image-1`, save it under `<session_dir>/photos/`, and surface
+a system message in chat with a clickable file:// link. macOS auto-opens.
+
+The whole subsystem is intentionally simple — no in-terminal rendering, no
+fallback providers, no caching. Anthropic / Ollama / remote do not generate.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class PhotoState:
+    enabled: bool = False
+    session_photos_dir: Path | None = None
+    sent_count: int = 0
+    max_per_session: int = 5
+    auto_open: bool = True
+
+    def can_send(self) -> bool:
+        return self.enabled and self.sent_count < self.max_per_session
+
+    def remaining(self) -> int:
+        return max(0, self.max_per_session - self.sent_count)
+
+
+def _slugify(text: str) -> str:
+    cleaned = re.sub(r"[^a-zA-Z0-9가-힣\s_-]", "", text).strip()
+    cleaned = re.sub(r"\s+", "-", cleaned)
+    return cleaned[:40] or "photo"
+
+
+def generate_photo(
+    prompt: str,
+    persona_name: str,
+    out_dir: Path,
+    *,
+    size: str = "1024x1024",
+    model: str = "gpt-image-1",
+) -> Path:
+    """Call OpenAI image API and write the PNG. Returns the saved path."""
+    if not os.getenv("OPENAI_API_KEY"):
+        raise RuntimeError("OPENAI_API_KEY is not set.")
+
+    from openai import OpenAI
+
+    client = OpenAI()
+    full_prompt = (
+        f"A casual smartphone photo that {persona_name} would naturally text. "
+        f"Subject: {prompt}. "
+        "Style: candid, slightly imperfect framing, warm phone-camera tone, "
+        "no text overlays, no watermarks, no logos."
+    )
+    response = client.images.generate(
+        model=model,
+        prompt=full_prompt,
+        size=size,
+        n=1,
+    )
+    data = response.data[0]
+    b64 = getattr(data, "b64_json", None)
+    if not b64:
+        url = getattr(data, "url", "")
+        if not url:
+            raise RuntimeError("Image API returned no usable payload.")
+        from urllib.request import urlopen
+        with urlopen(url, timeout=30) as resp:
+            blob = resp.read()
+    else:
+        blob = base64.b64decode(b64)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    fname = f"{timestamp}-{_slugify(prompt)}.png"
+    path = out_dir / fname
+    path.write_bytes(blob)
+    return path
+
+
+def open_in_default_app(path: Path) -> None:
+    """Best-effort: open the file in the OS default viewer. Silent on failure."""
+    try:
+        if sys.platform == "darwin":
+            subprocess.Popen(
+                ["open", str(path)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        elif sys.platform.startswith("linux"):
+            subprocess.Popen(
+                ["xdg-open", str(path)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+    except Exception:
+        pass
+
+
+def render_photo_message(path: Path, prompt: str, remaining: int) -> str:
+    """System-message text shown in chat after a photo is delivered."""
+    file_url = f"file://{path.resolve()}"
+    suffix = f" · {remaining}장 남음" if remaining >= 0 else ""
+    return f"📷 사진 도착 — {prompt}\n   {file_url}{suffix}"

--- a/src/girlfriend_generator/providers.py
+++ b/src/girlfriend_generator/providers.py
@@ -319,6 +319,8 @@ class OpenAIProvider:
                                 core_personality=str(kwargs.get("core_personality", "")),
                                 current_situation=str(kwargs.get("current_situation", "")),
                                 nudge_examples=list(kwargs.get("nudge_examples", []) or []),
+                                photos_enabled=bool(kwargs.get("photos_enabled", False)),
+                                photos_remaining=int(kwargs.get("photos_remaining", 0) or 0),
                             ),
                         }
                     ],
@@ -368,6 +370,7 @@ class OpenAIProvider:
             should_burst=bool(parsed.get("should_burst", False)),
             burst_messages=burst_list,
             next_proactive_seconds=proactive_s,
+            photo_prompt=str(parsed.get("photo_prompt") or ""),
         )
 
     def generate_initiative(
@@ -466,6 +469,8 @@ class AnthropicProvider:
                 core_personality=str(kwargs.get("core_personality", "")),
                 current_situation=str(kwargs.get("current_situation", "")),
                 nudge_examples=list(kwargs.get("nudge_examples", []) or []),
+                photos_enabled=bool(kwargs.get("photos_enabled", False)),
+                photos_remaining=int(kwargs.get("photos_remaining", 0) or 0),
             ),
             messages=[
                 {
@@ -500,6 +505,7 @@ class AnthropicProvider:
             coach_charm_point=str(parsed.get("user_charm_point", "")),
             coach_charm_type=str(parsed.get("user_charm_type", "")),
             coach_charm_feedback=str(parsed.get("user_charm_feedback", "")),
+            photo_prompt=str(parsed.get("photo_prompt") or ""),
         )
 
     def generate_initiative(
@@ -624,6 +630,8 @@ def _build_system_prompt(
     core_personality: str = "",
     current_situation: str = "",
     nudge_examples: list[str] | None = None,
+    photos_enabled: bool = False,
+    photos_remaining: int = 0,
 ) -> str:
     time_ctx = ""
     if current_time:
@@ -744,7 +752,19 @@ def _build_system_prompt(
         '  "next_proactive_seconds": integer OR null — if you want to proactively send ANOTHER '
         "message later without waiting for user (e.g. '아 맞다 한 가지 더', '나 방금 이거 생각났어'), "
         "set to 30-600. null = wait for user response normally.\n"
-        "}\n\n"
+        + (
+            (
+                '  ,"photo_prompt": string OR null — IF and only if it would feel natural for '
+                "this persona to send a phone photo right now (selfie / what they are looking at / "
+                "something they want to show off / a meme they took). Write a short visual "
+                "description (English or Korean, 1 sentence, no people identifiable by real name). "
+                "Otherwise null. Use sparingly — 사진은 가끔만, 흐름이 자연스러울 때만. "
+                f"You have {photos_remaining} photos left this session.\n"
+            )
+            if photos_enabled
+            else ""
+        )
+        + "}\n\n"
         f"Your identity: {persona.name}, {persona.age}세, {relationship_label or persona.relationship_mode}.\n"
         f"Background: {persona.background}\n"
         f"Texting style: {persona.texting_style}\n"

--- a/tests/test_photo.py
+++ b/tests/test_photo.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+
+from girlfriend_generator.photo import (
+    PhotoState,
+    _slugify,
+    render_photo_message,
+)
+
+
+def test_photo_state_disabled_by_default() -> None:
+    state = PhotoState()
+    assert state.enabled is False
+    assert state.can_send() is False
+    assert state.remaining() == 5
+
+
+def test_photo_state_caps_per_session() -> None:
+    state = PhotoState(enabled=True)
+    assert state.can_send() is True
+    state.sent_count = 5
+    assert state.can_send() is False
+    assert state.remaining() == 0
+
+
+def test_photo_state_remaining_clamps_negative() -> None:
+    state = PhotoState(enabled=True, max_per_session=3)
+    state.sent_count = 100
+    assert state.remaining() == 0
+
+
+def test_slugify_handles_korean_and_strips_punctuation() -> None:
+    out = _slugify("창문 밖 풍경 — !!!")
+    assert "창문" in out
+    assert "!" not in out
+    assert "—" not in out
+
+
+def test_slugify_falls_back_when_empty() -> None:
+    assert _slugify("###@@@") == "photo"
+
+
+def test_slugify_truncates() -> None:
+    long = "ab" * 50
+    assert len(_slugify(long)) <= 40
+
+
+def test_render_photo_message_includes_clickable_path(tmp_path: Path) -> None:
+    photo = tmp_path / "shot.png"
+    photo.write_bytes(b"\x89PNG")
+    rendered = render_photo_message(photo, "selfie at the desk", remaining=4)
+    assert "selfie at the desk" in rendered
+    assert f"file://{photo.resolve()}" in rendered
+    assert "4장 남음" in rendered
+
+
+def test_provider_reply_includes_photo_prompt_field() -> None:
+    from girlfriend_generator.models import ProviderReply
+    reply = ProviderReply(text="hi", typing_seconds=1.0, trace_note="test")
+    assert hasattr(reply, "photo_prompt")
+    assert reply.photo_prompt == ""
+
+
+def test_pending_delivery_carries_photo_prompt() -> None:
+    from girlfriend_generator.app import PendingDelivery
+    delivery = PendingDelivery(
+        kind="reply",
+        text="hi",
+        due_at=0.0,
+        trace_note="t",
+        photo_prompt="selfie at desk",
+    )
+    assert delivery.photo_prompt == "selfie at desk"
+
+
+def test_cli_photos_flag_defaults_off() -> None:
+    from girlfriend_generator.cli import build_parser
+    args = build_parser().parse_args([])
+    assert args.photos is False
+    assert args.photos_no_open is False
+
+
+def test_cli_photos_flag_can_be_enabled() -> None:
+    from girlfriend_generator.cli import build_parser
+    args = build_parser().parse_args(["--photos", "--photos-no-open"])
+    assert args.photos is True
+    assert args.photos_no_open is True


### PR DESCRIPTION
## Summary

Adds an opt-in feature where the persona can autonomously decide to send a phone-style photo during a conversation. Closes the spirit of #19 (multimodal) — for images at least.

**Duct-tape philosophy** (per request): smallest viable end-to-end path. No in-terminal rendering, no cross-provider abstraction, no caching.

## How it works

1. User opts in with \`--photos\` (default OFF — image API costs apply)
2. The system prompt gains an extra JSON slot \`photo_prompt\` *only when photos_enabled* — the LLM doesn't even know the option exists otherwise
3. When the persona naturally wants to send a photo, it fills \`photo_prompt\` with a short visual description
4. After the text reply is delivered, a background thread:
   - calls OpenAI \`gpt-image-1\`
   - saves PNG to \`<session_dir>/photos/<timestamp>-<slug>.png\`
   - posts a system message in chat: \`📷 사진 도착 — <prompt>\\n   file://...\`
   - on macOS, auto-opens with \`open\` (suppress with \`--photos-no-open\`)
5. Capped at **5 photos per session**; on failure the slot is refunded
6. Restricted to the OpenAI provider (Anthropic/Ollama don't have image gen here)

## Files

- \`src/girlfriend_generator/photo.py\` — new module
- \`src/girlfriend_generator/cli.py\` — \`--photos\`, \`--photos-no-open\`
- \`src/girlfriend_generator/app.py\` — wires PhotoState into main loop, \`_spawn_photo_job\` helper
- \`src/girlfriend_generator/providers.py\` — system prompt slot, parses \`photo_prompt\` from both OpenAI + Anthropic responses
- \`src/girlfriend_generator/models.py\` — \`ProviderReply.photo_prompt\` field
- \`tests/test_photo.py\` — 11 new tests

## Test plan

- [x] \`uv run pytest\` — 123 passing (was 112)
- [ ] Manual: \`OPENAI_API_KEY=... uv run mygf --photos\`, then provoke the persona ('너 셀카 보여줘' / '지금 뭐 보고 있어?') → confirm photo lands within 5–10s
- [ ] Manual: send 6 photo-bait messages → 6th should not trigger generation (cap reached)
- [ ] Manual: \`uv run mygf --provider anthropic --photos\` → flag accepted but no photos generated (provider gate)

## Cost note

\`gpt-image-1\` 1024x1024 ≈ \$0.04 per image. With 5/session cap that's ~\$0.20/session worst case. Off by default keeps users from accidentally burning budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)