### PR TITLE
feat: add read receipts to chat UI

### DIFF
--- a/src/girlfriend_generator/app.py
+++ b/src/girlfriend_generator/app.py
@@ -269,6 +269,7 @@ def run_chat_app(config: AppConfig) -> int:
     status_line = t("prompt_message_input")
     pending_job: BackgroundJob | None = None
     pending_delivery: PendingDelivery | None = None
+    pending_user_delivered_at: float | None = None
     last_key_at = time.monotonic()
     show_trace = config.show_trace
     last_render_key: tuple[Any, ...] | None = None
@@ -315,6 +316,21 @@ def run_chat_app(config: AppConfig) -> int:
                             previous_delivery=pending_delivery,
                             previous_status=status_line,
                         )
+
+                if (
+                    pending_user_delivered_at is not None
+                    and time.monotonic() >= pending_user_delivered_at
+                ):
+                    session.mark_last_user_message("delivered")
+                    pending_user_delivered_at = None
+
+                if (
+                    pending_delivery is not None
+                    and pending_delivery.kind == "reply"
+                    and pending_delivery.typing_starts_at is not None
+                    and time.monotonic() >= pending_delivery.typing_starts_at
+                ):
+                    session.mark_last_user_message("seen")
 
                 if pending_delivery and time.monotonic() >= pending_delivery.due_at:
                     delivered_text = pending_delivery.text
@@ -460,7 +476,9 @@ def run_chat_app(config: AppConfig) -> int:
                         photo_state=photo_state,
                     )
                     draft = outcome["draft"]
-                    scroll_offset = 0 if outcome.get("sent") else scroll_offset
+                    if outcome.get("sent"):
+                        scroll_offset = 0
+                        pending_user_delivered_at = time.monotonic() + 0.45
                     # Strategy discussion
                     if outcome.get("strategy"):
                         _show_strategy_discussion(
@@ -1284,9 +1302,7 @@ def _finish_job(
         else:
             session.proactive_due_at = None
 
-        # Add "seen" delay before typing indicator shows (1-2.5s)
-        import random
-        seen_delay = random.uniform(1.0, 2.5)
+        seen_delay = session.seen_delay_seconds()
         now = time.monotonic()
         trace_extra = f" | thought: {reply.internal_thought}" if reply.internal_thought else ""
         delivery = PendingDelivery(
@@ -1864,14 +1880,9 @@ def _render_chat(console: Console, session: ConversationSession, assistant_typin
         visible_messages = session.messages
     history = _fit_messages(visible_messages, available_lines)
     blocks = []
-    for i, message in enumerate(history):
-        is_read = True
-        if message.role == "user":
-            remaining = history[i + 1:]
-            is_read = any(m.role == "assistant" for m in remaining)
+    for message in history:
         blocks.append(_render_message(
             message, available_width,
-            is_read=is_read,
             persona_name=session.persona.name,
             accent=session.persona.accent_color,
         ))
@@ -1923,10 +1934,17 @@ def _fit_messages(messages: list[ChatMessage], max_lines: int) -> list[ChatMessa
     return result
 
 
+def _read_receipt_marker(state: str) -> str:
+    if state == "seen":
+        return "[bright_cyan]✓✓[/bright_cyan]"
+    if state == "delivered":
+        return "[grey62]✓✓[/grey62]"
+    return "[grey42]✓[/grey42]"
+
+
 def _render_message(
     message: ChatMessage,
     width: int,
-    is_read: bool = True,
     persona_name: str = "",
     accent: str = "magenta",
 ):
@@ -1936,7 +1954,7 @@ def _render_message(
     max_chars = bubble_width * 4
     display_text = message.text if len(message.text) <= max_chars else message.text[:max_chars] + "..."
     if message.role == "user":
-        read_mark = "[bright_cyan]✓✓[/bright_cyan]" if is_read else "[dim]✓[/dim]"
+        read_mark = _read_receipt_marker(message.read_state)
         content = Text(display_text, style="white")
         return Align.right(
             Panel(

--- a/src/girlfriend_generator/engine.py
+++ b/src/girlfriend_generator/engine.py
@@ -153,13 +153,50 @@ class ConversationSession:
 
     def add_user_message(self, text: str, now: datetime | None = None) -> None:
         now = now or utc_now()
-        self.messages.append(ChatMessage(role="user", text=text, created_at=now))
+        self.messages.append(
+            ChatMessage(role="user", text=text, created_at=now, read_state="sent")
+        )
         self.awaiting_user_reply = False
         self.nudge_due_at = None
         self.nudge_count = 0
         self.schedule_initiative(now)
         # Affection and mood are now judged by LLM, not keywords
         self.last_activity_at = now
+
+    def mark_last_user_message(self, state: str, now: datetime | None = None) -> None:
+        """Advance the latest user message from sent to delivered to seen."""
+        order = {"sent": 0, "delivered": 1, "seen": 2}
+        if state not in order:
+            return
+        for message in reversed(self.messages):
+            if message.role != "user":
+                continue
+            if order[state] > order.get(message.read_state, 0):
+                message.read_state = state  # type: ignore[assignment]
+                if state == "seen" and message.seen_at is None:
+                    message.seen_at = now or utc_now()
+            return
+
+    def seen_delay_seconds(self) -> float:
+        """Persona+mood-aware delay before the message flips to seen."""
+        import random
+
+        warmth = getattr(self.persona.style_profile, "warmth", 0.7)
+        directness = getattr(self.persona.style_profile, "directness", 0.55)
+        base = random.uniform(1.0, 2.5)
+        warmth_pull = (warmth - 0.5) * 1.6
+        direct_pull = (directness - 0.5) * 0.6
+        mood_bias = {
+            "happy": -0.4,
+            "excited": -0.6,
+            "flirty": -0.3,
+            "playful": -0.2,
+            "neutral": 0.0,
+            "worried": 0.4,
+            "sulky": 1.2,
+        }.get(self.mood.current, 0.0)
+        delay = base - warmth_pull - direct_pull + mood_bias
+        return max(0.4, min(delay, 6.0))
 
     def add_assistant_message(
         self,

--- a/src/girlfriend_generator/models.py
+++ b/src/girlfriend_generator/models.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 MessageRole = Literal["user", "assistant", "system"]
 MoodType = Literal["neutral", "happy", "playful", "sulky", "excited", "worried", "flirty"]
+ReadState = Literal["sent", "delivered", "seen"]
 
 MOOD_EMOJI: dict[str, str] = {
     "neutral": "😐",
@@ -123,6 +124,8 @@ class ChatMessage:
     role: MessageRole
     text: str
     created_at: datetime
+    read_state: ReadState = "sent"
+    seen_at: datetime | None = None
 
 
 @dataclass(slots=True)

--- a/src/girlfriend_generator/session_io.py
+++ b/src/girlfriend_generator/session_io.py
@@ -46,14 +46,7 @@ def export_session(
             },
         },
         "relationship_state": relationship_state or {},
-        "messages": [
-            {
-                "role": message.role,
-                "text": message.text,
-                "created_at": message.created_at.isoformat(),
-            }
-            for message in messages
-        ],
+        "messages": [_serialize_message(message) for message in messages],
     }
     json_path.write_text(
         json.dumps(payload, ensure_ascii=False, indent=2),
@@ -108,17 +101,42 @@ def load_session_snapshot(path: Path) -> tuple[list[ChatMessage], dict]:
     return _parse_messages(payload), dict(payload.get("relationship_state", {}))
 
 
+def _serialize_message(message: ChatMessage) -> dict:
+    payload: dict = {
+        "role": message.role,
+        "text": message.text,
+        "created_at": message.created_at.isoformat(),
+    }
+    if message.role == "user" and message.read_state != "sent":
+        payload["read_state"] = message.read_state
+        if message.seen_at is not None:
+            payload["seen_at"] = message.seen_at.isoformat()
+    return payload
+
+
 def _parse_messages(payload: dict) -> list[ChatMessage]:
     messages = []
     for item in payload.get("messages", []):
         created_at = datetime.fromisoformat(item["created_at"])
         if created_at.tzinfo is None:
             created_at = created_at.replace(tzinfo=timezone.utc)
+        read_state = item.get("read_state", "sent") if item.get("role") == "user" else "sent"
+        seen_at = None
+        seen_raw = item.get("seen_at")
+        if seen_raw:
+            try:
+                seen_at = datetime.fromisoformat(seen_raw)
+                if seen_at.tzinfo is None:
+                    seen_at = seen_at.replace(tzinfo=timezone.utc)
+            except ValueError:
+                seen_at = None
         messages.append(
             ChatMessage(
                 role=item["role"],
                 text=item["text"],
                 created_at=created_at,
+                read_state=read_state,
+                seen_at=seen_at,
             )
         )
     return messages

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,9 @@ from girlfriend_generator.app import (
     _handle_command,
     _handle_key,
     _localized_relationship_label,
+    _read_receipt_marker,
     _render_header,
+    _render_message,
     _render_screen,
     _render_trace,
     _show_full_coach_panel,
@@ -271,6 +273,30 @@ def test_render_trace_shows_charm_feedback() -> None:
     assert "Charm" in rendered
     assert "playful" in rendered
     assert "장난기 있는 리듬감" in rendered
+
+
+def test_read_receipt_marker_progression_renders_expected_states() -> None:
+    assert _read_receipt_marker("sent") == "[grey42]✓[/grey42]"
+    assert _read_receipt_marker("delivered") == "[grey62]✓✓[/grey62]"
+    assert _read_receipt_marker("seen") == "[bright_cyan]✓✓[/bright_cyan]"
+
+
+def test_render_message_uses_double_check_for_delivered_user_messages() -> None:
+    persona = _load_test_persona()
+    session = ConversationSession(persona=persona)
+    session.add_user_message("읽음 체크 테스트")
+    session.mark_last_user_message("delivered")
+
+    rendered = _render_to_text(
+        _render_message(
+            session.messages[-1],
+            width=60,
+            persona_name=persona.name,
+            accent=persona.accent_color,
+        )
+    )
+
+    assert "✓✓" in rendered
 
 
 def test_sync_provider_trace_exposes_remote_metadata() -> None:

--- a/tests/test_read_receipts.py
+++ b/tests/test_read_receipts.py
@@ -1,0 +1,119 @@
+"""Tests for user-message read receipts."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from girlfriend_generator.engine import ConversationSession
+from girlfriend_generator.models import ChatMessage
+from girlfriend_generator.personas import load_persona
+from girlfriend_generator.session_io import _parse_messages, _serialize_message
+
+
+def _persona():
+    return load_persona(Path("personas/dua-international.json"))
+
+
+def test_new_user_message_starts_as_sent() -> None:
+    session = ConversationSession(persona=_persona())
+    session.add_user_message("hey")
+
+    last = next(message for message in reversed(session.messages) if message.role == "user")
+
+    assert last.read_state == "sent"
+    assert last.seen_at is None
+
+
+def test_mark_progresses_sent_to_delivered_to_seen() -> None:
+    session = ConversationSession(persona=_persona())
+    session.add_user_message("hi")
+
+    session.mark_last_user_message("delivered")
+    last = next(message for message in reversed(session.messages) if message.role == "user")
+    assert last.read_state == "delivered"
+
+    session.mark_last_user_message("seen")
+    last = next(message for message in reversed(session.messages) if message.role == "user")
+    assert last.read_state == "seen"
+    assert last.seen_at is not None
+
+
+def test_mark_does_not_regress() -> None:
+    session = ConversationSession(persona=_persona())
+    session.add_user_message("hi")
+
+    session.mark_last_user_message("seen")
+    session.mark_last_user_message("sent")
+
+    last = next(message for message in reversed(session.messages) if message.role == "user")
+    assert last.read_state == "seen"
+
+
+def test_mark_only_touches_latest_user_message() -> None:
+    session = ConversationSession(persona=_persona())
+    session.add_user_message("first")
+    session.add_assistant_message("hi", schedule_nudge=False)
+    session.add_user_message("second")
+
+    session.mark_last_user_message("seen")
+
+    user_messages = [message for message in session.messages if message.role == "user"]
+    assert user_messages[0].read_state == "sent"
+    assert user_messages[1].read_state == "seen"
+
+
+def test_seen_delay_is_persona_aware_and_within_bounds() -> None:
+    session = ConversationSession(persona=_persona())
+
+    samples = [session.seen_delay_seconds() for _ in range(20)]
+
+    assert all(0.4 <= sample <= 6.0 for sample in samples)
+
+
+def test_seen_delay_warm_persona_faster_than_cold() -> None:
+    persona = _persona()
+    persona.style_profile.warmth = 0.95
+    persona.style_profile.directness = 0.9
+    warm = ConversationSession(persona=persona)
+
+    cold = ConversationSession(persona=_persona())
+    cold.persona.style_profile.warmth = 0.05
+    cold.persona.style_profile.directness = 0.1
+    cold.mood.shift("sulky", intensity=0.9)
+
+    warm_avg = sum(warm.seen_delay_seconds() for _ in range(40)) / 40
+    cold_avg = sum(cold.seen_delay_seconds() for _ in range(40)) / 40
+
+    assert warm_avg < cold_avg, (warm_avg, cold_avg)
+
+
+def test_session_io_roundtrip_preserves_read_state() -> None:
+    message = ChatMessage(
+        role="user",
+        text="hi",
+        created_at=datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+        read_state="seen",
+        seen_at=datetime(2026, 4, 30, 12, 0, 2, tzinfo=timezone.utc),
+    )
+    payload = {"messages": [_serialize_message(message)]}
+
+    parsed = _parse_messages(payload)
+
+    assert parsed[0].read_state == "seen"
+    assert parsed[0].seen_at is not None
+    assert parsed[0].seen_at.tzinfo is not None
+
+
+def test_session_io_legacy_messages_default_to_sent() -> None:
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "text": "legacy",
+                "created_at": datetime(2026, 4, 1, tzinfo=timezone.utc).isoformat(),
+            }
+        ]
+    }
+
+    parsed = _parse_messages(payload)
+
+    assert parsed[0].read_state == "sent"


### PR DESCRIPTION
Closes #13

## Summary
- Adds explicit user-message read states: sent, delivered, seen.
- Advances read state in the live chat loop instead of inferring it from later assistant messages.
- Persists read state and seen timestamps through session export/load.
- Makes seen timing persona/mood-aware and renders single/double-check markers in user bubbles.

## Verification
- ......................................................                   [100%]
54 passed in 0.11s