### PR TITLE
feat: track local usage time and metrics

### DIFF
--- a/src/girlfriend_generator/app.py
+++ b/src/girlfriend_generator/app.py
@@ -28,6 +28,7 @@ from .providers import ProviderConfig, build_provider
 from .session_io import export_session, load_session_snapshot
 from .music import build_music_player
 from .photo import PhotoState, generate_photo, open_in_default_app, render_photo_message
+from .usage_metrics import start_session as start_usage_session
 from .voice import build_voice_input, build_voice_output
 
 
@@ -244,6 +245,8 @@ def run_chat_app(config: AppConfig) -> int:
         voice_input_name=voice_input.name,
     )
     session = ConversationSession(persona=persona)
+    usage_session = None
+    resumed = bool(config.resume_path and config.resume_path.exists())
     if config.resume_path and config.resume_path.exists():
         resumed_messages, resumed_state = load_session_snapshot(config.resume_path)
         session.messages = resumed_messages
@@ -264,6 +267,14 @@ def run_chat_app(config: AppConfig) -> int:
     else:
         session.bootstrap()
         _localize_session_display_state(provider, persona, session)
+    usage_session = start_usage_session(
+        persona_name=persona.name,
+        persona_path=str(config.persona_path),
+        provider_name=config.provider_name,
+        provider_model=config.provider_model,
+        performance_mode=config.performance_mode,
+        resumed=resumed,
+    )
 
     draft = ""
     status_line = t("prompt_message_input")
@@ -527,6 +538,8 @@ def run_chat_app(config: AppConfig) -> int:
                     )
                     last_render_key = render_key
     finally:
+        if usage_session is not None:
+            usage_session.finish()
         music_player.stop()
         if config.export_on_exit and session.messages:
             export_session(

--- a/src/girlfriend_generator/cli.py
+++ b/src/girlfriend_generator/cli.py
@@ -419,6 +419,9 @@ def main() -> int:
     parser = build_parser()
     raw_args = sys.argv[1:]
     args = parser.parse_args(raw_args)
+    from .usage_metrics import record_app_launch
+
+    record_app_launch()
     _apply_saved_runtime_settings(args, parser, raw_args)
     _apply_provider_defaults(args)
     persona_dir = bundled_persona_dir()

--- a/src/girlfriend_generator/usage_metrics.py
+++ b/src/girlfriend_generator/usage_metrics.py
@@ -1,0 +1,194 @@
+"""Local-first usage metrics for product decisions.
+
+The metrics file intentionally stores coarse session metadata only. It never
+stores transcript text, user prompts, assistant replies, or API keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+
+_STATE_DIR_ENV = "GIRLFRIEND_IN_CLI_HOME"
+_DEFAULT_DIRNAME = ".girlfriend-in-cli"
+_FILENAME = "usage_metrics.json"
+_SCHEMA_VERSION = 1
+_MAX_EVENTS = 200
+
+
+def state_dir() -> Path:
+    override = os.environ.get(_STATE_DIR_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / _DEFAULT_DIRNAME
+
+
+def metrics_path() -> Path:
+    return state_dir() / _FILENAME
+
+
+def _utc_iso(now: datetime | None = None) -> str:
+    return (now or datetime.now(tz=timezone.utc)).isoformat()
+
+
+def _empty_metrics() -> dict:
+    return {
+        "version": _SCHEMA_VERSION,
+        "total_active_seconds": 0.0,
+        "sessions_total": 0,
+        "sessions_resumed": 0,
+        "events": [],
+    }
+
+
+def load_metrics(path: Path | None = None) -> dict:
+    target = path or metrics_path()
+    if not target.exists():
+        return _empty_metrics()
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _empty_metrics()
+    if not isinstance(payload, dict):
+        return _empty_metrics()
+    metrics = _empty_metrics()
+    metrics.update(payload)
+    if not isinstance(metrics.get("events"), list):
+        metrics["events"] = []
+    metrics["total_active_seconds"] = float(metrics.get("total_active_seconds") or 0.0)
+    metrics["sessions_total"] = int(metrics.get("sessions_total") or 0)
+    metrics["sessions_resumed"] = int(metrics.get("sessions_resumed") or 0)
+    return metrics
+
+
+def save_metrics(metrics: dict, path: Path | None = None) -> None:
+    target = path or metrics_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(metrics, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def record_event(
+    event_type: str,
+    metadata: dict[str, object] | None = None,
+    *,
+    path: Path | None = None,
+    now: datetime | None = None,
+) -> None:
+    metrics = load_metrics(path)
+    event = {
+        "type": event_type,
+        "at": _utc_iso(now),
+        "metadata": _safe_metadata(metadata or {}),
+    }
+    metrics["events"] = [*metrics.get("events", []), event][-_MAX_EVENTS:]
+    save_metrics(metrics, path)
+
+
+def record_app_launch(*, path: Path | None = None) -> None:
+    record_event("app_launched", path=path)
+
+
+def _safe_metadata(metadata: dict[str, object]) -> dict[str, object]:
+    allowed = {
+        "persona_name",
+        "persona_path",
+        "provider_name",
+        "provider_model",
+        "performance_mode",
+        "resumed",
+        "duration_seconds",
+    }
+    return {key: value for key, value in metadata.items() if key in allowed}
+
+
+@dataclass
+class UsageSession:
+    persona_name: str
+    persona_path: str
+    provider_name: str
+    provider_model: str | None
+    performance_mode: str
+    resumed: bool
+    path: Path | None = None
+    clock: Callable[[], float] = time.monotonic
+    started_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    _started_monotonic: float = 0.0
+    _finished: bool = False
+
+    def __post_init__(self) -> None:
+        self._started_monotonic = self.clock()
+        metrics = load_metrics(self.path)
+        metrics["sessions_total"] = int(metrics.get("sessions_total") or 0) + 1
+        if self.resumed:
+            metrics["sessions_resumed"] = int(metrics.get("sessions_resumed") or 0) + 1
+        metrics["events"] = [
+            *metrics.get("events", []),
+            {
+                "type": "session_started" if not self.resumed else "session_resumed",
+                "at": _utc_iso(self.started_at),
+                "metadata": self._metadata(),
+            },
+        ][-_MAX_EVENTS:]
+        save_metrics(metrics, self.path)
+
+    def finish(self, *, ended_at: datetime | None = None) -> float:
+        if self._finished:
+            return 0.0
+        self._finished = True
+        duration = max(0.0, self.clock() - self._started_monotonic)
+        metrics = load_metrics(self.path)
+        metrics["total_active_seconds"] = round(
+            float(metrics.get("total_active_seconds") or 0.0) + duration,
+            3,
+        )
+        metrics["events"] = [
+            *metrics.get("events", []),
+            {
+                "type": "session_ended",
+                "at": _utc_iso(ended_at),
+                "metadata": {**self._metadata(), "duration_seconds": round(duration, 3)},
+            },
+        ][-_MAX_EVENTS:]
+        save_metrics(metrics, self.path)
+        return duration
+
+    def _metadata(self) -> dict[str, object]:
+        return _safe_metadata(
+            {
+                "persona_name": self.persona_name,
+                "persona_path": self.persona_path,
+                "provider_name": self.provider_name,
+                "provider_model": self.provider_model or "",
+                "performance_mode": self.performance_mode,
+                "resumed": self.resumed,
+            }
+        )
+
+
+def start_session(
+    *,
+    persona_name: str,
+    persona_path: str,
+    provider_name: str,
+    provider_model: str | None,
+    performance_mode: str,
+    resumed: bool,
+    path: Path | None = None,
+    clock: Callable[[], float] = time.monotonic,
+) -> UsageSession:
+    return UsageSession(
+        persona_name=persona_name,
+        persona_path=persona_path,
+        provider_name=provider_name,
+        provider_model=provider_model,
+        performance_mode=performance_mode,
+        resumed=resumed,
+        path=path,
+        clock=clock,
+    )

--- a/tests/test_usage_metrics.py
+++ b/tests/test_usage_metrics.py
@@ -1,0 +1,85 @@
+"""Tests for local-first usage metrics."""
+
+from pathlib import Path
+
+from girlfriend_generator import usage_metrics
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 10.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_session_duration_persists_across_loads(tmp_path: Path) -> None:
+    path = tmp_path / "usage_metrics.json"
+    clock = FakeClock()
+    session = usage_metrics.start_session(
+        persona_name="Yu-na",
+        persona_path="personas/yu-na.json",
+        provider_name="openai",
+        provider_model="gpt-5.4",
+        performance_mode="turbo",
+        resumed=False,
+        path=path,
+        clock=clock,
+    )
+
+    clock.now += 12.5
+    duration = session.finish()
+
+    metrics = usage_metrics.load_metrics(path)
+    assert duration == 12.5
+    assert metrics["total_active_seconds"] == 12.5
+    assert metrics["sessions_total"] == 1
+    assert metrics["events"][-1]["type"] == "session_ended"
+
+
+def test_resumed_session_counter_and_event_are_recorded(tmp_path: Path) -> None:
+    path = tmp_path / "usage_metrics.json"
+    session = usage_metrics.start_session(
+        persona_name="Yu-na",
+        persona_path="personas/yu-na.json",
+        provider_name="anthropic",
+        provider_model="claude-sonnet-4-6",
+        performance_mode="balanced",
+        resumed=True,
+        path=path,
+    )
+    session.finish()
+
+    metrics = usage_metrics.load_metrics(path)
+    assert metrics["sessions_total"] == 1
+    assert metrics["sessions_resumed"] == 1
+    assert metrics["events"][0]["type"] == "session_resumed"
+
+
+def test_metrics_do_not_store_transcript_text(tmp_path: Path) -> None:
+    path = tmp_path / "usage_metrics.json"
+    usage_metrics.record_event(
+        "session_started",
+        {
+            "persona_name": "Yu-na",
+            "provider_name": "openai",
+            "user_text": "this should never be stored",
+            "assistant_reply": "nor should this",
+        },
+        path=path,
+    )
+
+    raw = path.read_text(encoding="utf-8")
+    assert "this should never be stored" not in raw
+    assert "nor should this" not in raw
+    assert "Yu-na" in raw
+
+
+def test_load_metrics_recovers_from_corrupt_file(tmp_path: Path) -> None:
+    path = tmp_path / "usage_metrics.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    metrics = usage_metrics.load_metrics(path)
+
+    assert metrics["total_active_seconds"] == 0.0
+    assert metrics["events"] == []


### PR DESCRIPTION
Closes #5

## Summary
- Adds a local-first usage metrics store under the app state directory.
- Records app launch, session started/resumed, session ended, duration, persona, provider, and performance metadata.
- Counts active chat session duration only around run_chat_app, so main-menu idle time is not included.
- Filters metrics metadata to avoid storing transcript/user/assistant text.

## Verification
- python3 -m pytest tests/test_usage_metrics.py tests/test_app.py tests/test_cli.py -q