### PR TITLE
feat: react to terminal paste and scroll actions

### DIFF
--- a/src/girlfriend_generator/app.py
+++ b/src/girlfriend_generator/app.py
@@ -1323,9 +1323,14 @@ def _handle_key(
     is_scroll_up = key in ("\x1b[A", "\x1b[5~", "[")
     is_scroll_down = key in ("\x1b[B", "\x1b[6~", "]")
     if is_scroll_up and not draft:
+        reacted = _maybe_add_action_reaction(session, persona, "scroll")
         return {
             "draft": draft,
-            "status_line": "이전 대화 보는 중 · 입력창이 비어 있을 때 ↑↓로 이동",
+            "status_line": (
+                f"{persona.name} noticed you scrolling back. · 입력창이 비어 있을 때 ↑↓로 이동"
+                if reacted
+                else "이전 대화 보는 중 · 입력창이 비어 있을 때 ↑↓로 이동"
+            ),
             "pending_job": pending_job,
             "show_trace": show_trace,
             "voice_output_enabled": voice_output_enabled,
@@ -1457,9 +1462,16 @@ def _handle_key(
         }
 
     if key.isprintable():
+        reacted = False
+        if _looks_like_large_paste(key):
+            reacted = _maybe_add_action_reaction(session, persona, "paste", detail=len(key))
         return {
             "draft": draft + key,
-            "status_line": "Editing draft...",
+            "status_line": (
+                f"{persona.name} noticed the big paste."
+                if reacted
+                else "Editing draft..."
+            ),
             "pending_job": pending_job,
             "show_trace": show_trace,
             "voice_output_enabled": voice_output_enabled,
@@ -1474,6 +1486,32 @@ def _handle_key(
         "voice_output_enabled": voice_output_enabled,
         "quit": False,
     }
+
+
+def _looks_like_large_paste(key: str) -> bool:
+    return len(key) >= 80 or key.count("\n") >= 2
+
+
+def _maybe_add_action_reaction(
+    session: ConversationSession,
+    persona: Persona,
+    action: str,
+    detail: int | None = None,
+) -> bool:
+    if not session.action_reaction_due():
+        return False
+    if action == "paste":
+        line = (
+            f"{persona.name}: 이게 다 뭐야... {detail or '많은'}글자나 붙여넣었네. "
+            "천천히 같이 보자."
+        )
+    elif action == "scroll":
+        line = f"{persona.name}: 방금 예전 대화 다시 봤지? 뭐 찾는 거야?"
+    else:
+        return False
+    session.add_assistant_message(line, schedule_nudge=False)
+    session.record_action_reaction()
+    return True
 
 
 def _handle_command(
@@ -1499,6 +1537,26 @@ def _handle_command(
             "show_trace": show_trace,
             "voice_output_enabled": voice_output_enabled,
             "quit": True,
+        }
+    if lowered in {"/actions off", "/action-reactions off"}:
+        session.action_reactions_enabled = False
+        return {
+            "draft": "",
+            "status_line": "Non-text action reactions off.",
+            "pending_job": pending_job,
+            "show_trace": show_trace,
+            "voice_output_enabled": voice_output_enabled,
+            "quit": False,
+        }
+    if lowered in {"/actions on", "/action-reactions on"}:
+        session.action_reactions_enabled = True
+        return {
+            "draft": "",
+            "status_line": "Non-text action reactions on.",
+            "pending_job": pending_job,
+            "show_trace": show_trace,
+            "voice_output_enabled": voice_output_enabled,
+            "quit": False,
         }
     if lowered == "/back":
         return {

--- a/src/girlfriend_generator/engine.py
+++ b/src/girlfriend_generator/engine.py
@@ -65,6 +65,8 @@ class ConversationSession:
     strategy_uses_this_session: int = 0
     max_strategy_per_session: int = 3
     boundary_cooldown: bool = False
+    action_reactions_enabled: bool = True
+    last_action_reaction_at: datetime | None = None
 
     def __post_init__(self) -> None:
         self.relationship_state = RelationshipState(
@@ -101,6 +103,22 @@ class ConversationSession:
             self.mood.shift("happy", intensity=0.75)
         self.boundary_cooldown = True
         self.schedule_initiative(now)
+
+    def action_reaction_due(
+        self,
+        now: datetime | None = None,
+        cooldown_seconds: int = 45,
+    ) -> bool:
+        if not self.action_reactions_enabled:
+            return False
+        now = now or utc_now()
+        if self.last_action_reaction_at is None:
+            return True
+        elapsed = (now - self.last_action_reaction_at).total_seconds()
+        return elapsed >= cooldown_seconds
+
+    def record_action_reaction(self, now: datetime | None = None) -> None:
+        self.last_action_reaction_at = now or utc_now()
 
     @property
     def current_relationship_label(self) -> str:

--- a/tests/test_non_text_actions.py
+++ b/tests/test_non_text_actions.py
@@ -1,0 +1,115 @@
+"""Tests for persona reactions to non-text terminal actions."""
+
+from pathlib import Path
+
+from girlfriend_generator.app import _handle_command, _handle_key
+from girlfriend_generator.engine import ConversationSession, utc_now
+from girlfriend_generator.personas import load_persona
+from girlfriend_generator.voice import DisabledVoiceInput
+
+
+def _persona():
+    return load_persona(Path("personas/wonyoung-idol.json"))
+
+
+def _base_kwargs(session, persona):
+    return {
+        "session": session,
+        "persona": persona,
+        "provider": object(),
+        "pending_job": None,
+        "pending_delivery": None,
+        "voice_input": DisabledVoiceInput(),
+        "voice_output_available": False,
+        "voice_output_enabled": False,
+        "show_trace": True,
+        "session_dir": Path("sessions"),
+    }
+
+
+def _command_kwargs(session):
+    return {
+        "session": session,
+        "provider": object(),
+        "pending_job": None,
+        "pending_delivery": None,
+        "voice_input": DisabledVoiceInput(),
+        "voice_output_available": False,
+        "voice_output_enabled": False,
+        "show_trace": True,
+        "session_dir": Path("sessions"),
+    }
+
+
+def test_large_paste_triggers_persona_reaction() -> None:
+    persona = _persona()
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+    before = len(session.messages)
+
+    outcome = _handle_key(
+        key="x" * 120,
+        draft="",
+        **_base_kwargs(session, persona),
+    )
+
+    assert outcome["draft"] == "x" * 120
+    assert "noticed the big paste" in outcome["status_line"]
+    assert len(session.messages) == before + 1
+    assert session.messages[-1].role == "assistant"
+    assert "붙여넣었네" in session.messages[-1].text
+
+
+def test_scrollback_triggers_persona_reaction() -> None:
+    persona = _persona()
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+    before = len(session.messages)
+
+    outcome = _handle_key(
+        key="\x1b[A",
+        draft="",
+        **_base_kwargs(session, persona),
+    )
+
+    assert outcome["scroll_delta"] == 2
+    assert len(session.messages) == before + 1
+    assert session.messages[-1].role == "assistant"
+    assert "예전 대화" in session.messages[-1].text
+
+
+def test_non_text_reactions_are_rate_limited() -> None:
+    persona = _persona()
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+
+    _handle_key(key="x" * 120, draft="", **_base_kwargs(session, persona))
+    before = len(session.messages)
+    _handle_key(key="y" * 120, draft="", **_base_kwargs(session, persona))
+
+    assert len(session.messages) == before
+
+
+def test_action_reaction_kill_switch() -> None:
+    persona = _persona()
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+
+    off = _handle_command(
+        text="/actions off",
+        **_command_kwargs(session),
+    )
+    assert off["status_line"] == "Non-text action reactions off."
+
+    before = len(session.messages)
+    _handle_key(key="x" * 120, draft="", **_base_kwargs(session, persona))
+    assert len(session.messages) == before
+
+    on = _handle_command(
+        text="/actions on",
+        **_command_kwargs(session),
+    )
+    assert on["status_line"] == "Non-text action reactions on."
+    session.last_action_reaction_at = utc_now().replace(year=2000)
+    _handle_key(key="x" * 120, draft="", **_base_kwargs(session, persona))
+    assert len(session.messages) == before + 1


### PR DESCRIPTION
Closes #17

## Summary
- Adds persona reactions for two V1 non-text terminal signals: large paste and scrollback navigation.
- Keeps reactions as assistant messages rather than system notices so they feel persona-flavored.
- Adds rate limiting so repeated paste/scroll events do not spam the chat.
- Adds /actions off and /actions on as a kill switch.

## Verification
- python3 -m pytest tests/test_non_text_actions.py tests/test_app.py -q