### PR TITLE
feat: scaffold YouTube persona source ingest

### DIFF
--- a/docs/issues/issue-12-youtube-persona-generation.md
+++ b/docs/issues/issue-12-youtube-persona-generation.md
@@ -1,0 +1,33 @@
+# Issue #12: YouTube Persona Generation
+
+This PR adds the local normalization layer for YouTube persona sources without
+claiming to download media or run hosted STT yet.
+
+## Implemented
+
+- Validate supported YouTube video URLs:
+  - `youtube.com/watch?v=...`
+  - `youtu.be/...`
+  - `/shorts/...`
+  - `/embed/...`
+- Build a source-attributed persona context from:
+  - video metadata
+  - captions
+  - STT transcript text
+  - deep research notes
+- Route YouTube URLs through this context layer in the existing deep research
+  persona generator.
+- Add Persona Studio example copy for YouTube URLs.
+
+## Security / Privacy / Runtime Gate
+
+- No raw audio/video is downloaded in this PR.
+- No captions or transcripts are persisted by the ingest module.
+- Source context explicitly warns synthesis not to claim private facts.
+- Real caption/STT adapters must document provider boundaries, retention, and
+  copyright/source-attribution behavior before this issue can use `Closes`.
+
+## Not Closing Yet
+
+This does not yet implement live caption extraction, STT fallback execution, or
+hosted deep-research orchestration. The PR should use `Refs #12`.

--- a/src/girlfriend_generator/cli.py
+++ b/src/girlfriend_generator/cli.py
@@ -1370,6 +1370,7 @@ def _auto_generate_persona(
         "  [cyan]장원영[/cyan]\n"
         "  [cyan]Dua Lipa[/cyan]\n"
         "  [cyan]Reze from Chainsaw Man[/cyan]\n"
+        "  [cyan]https://www.youtube.com/watch?v=dQw4w9WgXcQ[/cyan]\n"
         "  [cyan]https://namu.wiki/w/아이유[/cyan]\n"
         "  [cyan]차가운 도시 여자 26살 변호사[/cyan]\n\n"
         "[dim]Or describe in detail (multi-line):[/dim]\n"

--- a/src/girlfriend_generator/persona_auto.py
+++ b/src/girlfriend_generator/persona_auto.py
@@ -204,8 +204,18 @@ def generate_persona_from_input(
 
     # Gather research context
     research_context = ""
+    try:
+        from .youtube_ingest import YouTubeIngestInput, build_youtube_persona_context, is_youtube_url
+    except Exception:
+        is_youtube_url = lambda _value: False  # type: ignore[assignment]
+        build_youtube_persona_context = None  # type: ignore[assignment]
+        YouTubeIngestInput = None  # type: ignore[assignment]
+
     if _looks_like_url(input_text):
-        research_context = _fetch_url_content(input_text)
+        if is_youtube_url(input_text) and build_youtube_persona_context is not None:
+            research_context = build_youtube_persona_context(YouTubeIngestInput(url=input_text))
+        else:
+            research_context = _fetch_url_content(input_text)
         if not research_context:
             research_context = _web_search_context(
                 input_text,
@@ -320,7 +330,18 @@ def deep_research_persona(
     _notify(1)
     research_chunks: list[str] = []
     if is_url or _looks_like_url(input_text):
-        html = _fetch_url_content(input_text)
+        try:
+            from .youtube_ingest import YouTubeIngestInput, build_youtube_persona_context, is_youtube_url
+        except Exception:
+            is_youtube_url = lambda _value: False  # type: ignore[assignment]
+            build_youtube_persona_context = None  # type: ignore[assignment]
+            YouTubeIngestInput = None  # type: ignore[assignment]
+
+        html = ""
+        if is_youtube_url(input_text) and build_youtube_persona_context is not None:
+            html = build_youtube_persona_context(YouTubeIngestInput(url=input_text))
+        else:
+            html = _fetch_url_content(input_text)
         if html:
             research_chunks.append(html)
 

--- a/src/girlfriend_generator/youtube_ingest.py
+++ b/src/girlfriend_generator/youtube_ingest.py
@@ -1,0 +1,98 @@
+"""YouTube source normalization for persona generation.
+
+This module is intentionally adapter-shaped: it validates YouTube URLs and
+combines metadata, captions, STT transcripts, and research notes into a compact
+prompt context without downloading media or storing raw audio locally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs, urlparse
+
+
+YOUTUBE_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "youtu.be",
+    "music.youtube.com",
+}
+
+
+@dataclass(frozen=True)
+class YouTubeSource:
+    url: str
+    video_id: str
+
+
+@dataclass(frozen=True)
+class YouTubeIngestInput:
+    url: str
+    title: str = ""
+    description: str = ""
+    channel: str = ""
+    captions: str = ""
+    stt_transcript: str = ""
+    research_notes: list[str] = field(default_factory=list)
+
+
+def parse_youtube_url(url: str) -> YouTubeSource:
+    parsed = urlparse(url.strip())
+    host = parsed.netloc.lower()
+    if host not in YOUTUBE_HOSTS:
+        raise ValueError("Not a supported YouTube URL.")
+
+    video_id = ""
+    if host == "youtu.be":
+        video_id = parsed.path.strip("/").split("/", 1)[0]
+    elif parsed.path == "/watch":
+        video_id = parse_qs(parsed.query).get("v", [""])[0]
+    elif parsed.path.startswith("/shorts/") or parsed.path.startswith("/embed/"):
+        video_id = parsed.path.strip("/").split("/", 1)[1]
+
+    if not video_id:
+        raise ValueError("YouTube URL must point to a specific video.")
+    return YouTubeSource(url=url.strip(), video_id=video_id)
+
+
+def is_youtube_url(value: str) -> bool:
+    try:
+        parse_youtube_url(value)
+        return True
+    except ValueError:
+        return False
+
+
+def build_youtube_persona_context(source: YouTubeIngestInput) -> str:
+    parsed = parse_youtube_url(source.url)
+    blocks = [
+        "=== YouTube persona source ===",
+        f"URL: {parsed.url}",
+        f"Video ID: {parsed.video_id}",
+    ]
+    if source.title:
+        blocks.append(f"Title: {source.title}")
+    if source.channel:
+        blocks.append(f"Channel: {source.channel}")
+    if source.description:
+        blocks.append("Description:\n" + _trim(source.description, 1200))
+    if source.captions:
+        blocks.append("Caption evidence:\n" + _trim(source.captions, 3500))
+    if source.stt_transcript:
+        blocks.append("STT fallback evidence:\n" + _trim(source.stt_transcript, 3500))
+    if source.research_notes:
+        blocks.append("Deep research notes:\n" + "\n".join(f"- {_trim(note, 600)}" for note in source.research_notes))
+    blocks.append(
+        "Synthesis instructions: infer speaking rhythm, repeated phrases, humor, warmth, "
+        "teasing, directness, and texting style from the evidence above. Keep source "
+        "attribution in context_summary; do not claim private facts."
+    )
+    return "\n\n".join(blocks)
+
+
+def _trim(value: str, limit: int) -> str:
+    compact = " ".join(value.split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3].rstrip() + "..."

--- a/tests/test_youtube_ingest.py
+++ b/tests/test_youtube_ingest.py
@@ -1,0 +1,55 @@
+"""Tests for YouTube persona source normalization."""
+
+import pytest
+
+from girlfriend_generator.youtube_ingest import (
+    YouTubeIngestInput,
+    build_youtube_persona_context,
+    is_youtube_url,
+    parse_youtube_url,
+)
+
+
+def test_parse_watch_url_extracts_video_id() -> None:
+    source = parse_youtube_url("https://www.youtube.com/watch?v=abc123XYZ_9")
+    assert source.video_id == "abc123XYZ_9"
+
+
+def test_parse_short_url_extracts_video_id() -> None:
+    source = parse_youtube_url("https://youtu.be/abc123XYZ_9")
+    assert source.video_id == "abc123XYZ_9"
+
+
+def test_parse_shorts_url_extracts_video_id() -> None:
+    source = parse_youtube_url("https://www.youtube.com/shorts/short123")
+    assert source.video_id == "short123"
+
+
+def test_parse_rejects_non_youtube_url() -> None:
+    with pytest.raises(ValueError):
+        parse_youtube_url("https://example.com/watch?v=abc")
+
+
+def test_is_youtube_url_handles_invalid_values() -> None:
+    assert is_youtube_url("https://www.youtube.com/watch?v=abc") is True
+    assert is_youtube_url("not a url") is False
+
+
+def test_build_context_includes_captions_stt_and_research_notes() -> None:
+    context = build_youtube_persona_context(
+        YouTubeIngestInput(
+            url="https://www.youtube.com/watch?v=abc123",
+            title="Interview with Mina",
+            channel="Mina Channel",
+            description="A long interview about work and love.",
+            captions="안녕하세요. 저는 천천히 말하는 편이에요.",
+            stt_transcript="음... 그러니까 저는 농담을 자주 해요.",
+            research_notes=["Public profile says she likes cafes."],
+        )
+    )
+
+    assert "Video ID: abc123" in context
+    assert "Caption evidence" in context
+    assert "STT fallback evidence" in context
+    assert "Deep research notes" in context
+    assert "do not claim private facts" in context


### PR DESCRIPTION
Refs #12

## Summary
- Adds YouTube URL validation and video-id extraction for watch, youtu.be, shorts, and embed URLs.
- Adds a local source-normalization layer that can combine metadata, captions, STT transcript text, and deep research notes into persona-generation context.
- Routes YouTube URLs through that context layer in the existing deep-research persona generator.
- Documents the security/privacy/runtime gate for future live caption and STT adapters.

## Not Closing Yet
This PR does not implement live caption extraction, media download, hosted STT fallback, transcript retention UX, or source-attribution UI. Those gates must land before #12 can be closed.

## Verification
- python3 -m pytest tests/test_youtube_ingest.py tests/test_personas.py -q