### PR TITLE
feat: add persona profile image fallbacks

### DIFF
--- a/personas/PERSONA_FORMAT.md
+++ b/personas/PERSONA_FORMAT.md
@@ -41,6 +41,13 @@ Create your own persona in a single JSON file. Share it as a Gist, a URL, or jus
   "provider_system_hint": "페르소나를 강화하는 추가 지시 (한 문장)",
   "context_summary": "한 줄 요약",
 
+  "profile_image": {
+    "url": "https://example.com/image.jpg",
+    "source": "auto_fetched",
+    "cached_path": "personas/.images/jieun.jpg",
+    "style": "real"
+  },
+
   "typing": {"min_seconds": 0.9, "max_seconds": 3.2},
 
   "nudge_policy": {
@@ -80,6 +87,28 @@ Create your own persona in a single JSON file. Share it as a Gist, a URL, or jus
 
 - `""` (기본): 일반
 - `"yandere"`: 집착형, burst 메시지 자동
+
+## Profile Images
+
+`profile_image` is optional. If it is missing, the chat UI shows a default initial avatar.
+
+```json
+{
+  "profile_image": {
+    "url": "https://example.com/image.jpg",
+    "source": "auto_fetched",
+    "cached_path": "personas/.images/jieun.jpg",
+    "style": "real"
+  }
+}
+```
+
+- `url`: original public image URL
+- `source`: `auto_fetched`, `user_uploaded`, or `generated`
+- `cached_path`: local cached file path, usually under `personas/.images/`
+- `style`: `real`, `anime`, or `illustration`
+- You can also use a simple string path/URL for quick imports, for example `"profile_image": "~/Pictures/jieun.jpg"`.
+- `/profile` shows the configured image metadata. Full inline terminal rendering is not enabled yet, so the chat header and message bubbles use a safe text avatar fallback.
 
 ## How to Share
 

--- a/src/girlfriend_generator/app.py
+++ b/src/girlfriend_generator/app.py
@@ -183,6 +183,45 @@ def _drain_pending_stdin() -> None:
             break
 
 
+def _profile_avatar_text(persona: Persona) -> str:
+    name = persona.name.strip()
+    initial = name[0].upper() if name else "?"
+    if persona.profile_image is None:
+        return f"[{initial}]"
+    style_icon = {
+        "anime": "AN",
+        "illustration": "IL",
+        "real": "PH",
+    }.get(persona.profile_image.style, "PH")
+    return f"[{style_icon}]"
+
+
+def _profile_image_message(persona: Persona) -> str:
+    avatar = _profile_avatar_text(persona)
+    image = persona.profile_image
+    if image is None:
+        return (
+            f"Profile Image\n"
+            f"Default avatar: {avatar}\n"
+            "No profile_image is configured for this persona yet."
+        )
+
+    lines = [
+        "Profile Image",
+        f"Avatar fallback: {avatar}",
+        f"Style: {image.style}",
+        f"Source: {image.source}",
+    ]
+    if image.cached_path:
+        lines.append(f"Cached path: {image.cached_path}")
+    if image.url:
+        lines.append(f"URL: {image.url}")
+    lines.append(
+        "Terminal image rendering is not enabled yet; showing the safe avatar fallback."
+    )
+    return "\n".join(lines)
+
+
 
 def _spawn_photo_job(
     *,
@@ -1525,11 +1564,22 @@ def _handle_command(
             "/export — save the session transcript\n"
             "/music — toggle mood music\n"
             "/voice on|off — toggle voice output\n"
-            "/listen — start voice input"
+            "/listen — start voice input\n"
+            "/profile — show persona profile image details"
         )
         return {
             "draft": "",
             "status_line": t("status_help_opened", lang),
+            "pending_job": pending_job,
+            "show_trace": show_trace,
+            "voice_output_enabled": voice_output_enabled,
+            "quit": False,
+        }
+    if lowered == "/profile":
+        session.add_system_message(_profile_image_message(session.persona))
+        return {
+            "draft": "",
+            "status_line": "Profile image posted.",
             "pending_job": pending_job,
             "show_trace": show_trace,
             "voice_output_enabled": voice_output_enabled,
@@ -1832,8 +1882,9 @@ def _render_header(persona: Persona, session: ConversationSession):
     else:
         mode_icon = {"girlfriend": "💕", "crush": "💘"}.get(persona.relationship_mode, "💬")
 
+    avatar = _profile_avatar_text(persona)
     body = Text.assemble(
-        (f" {mode_icon} ", ""),
+        (f" {avatar} {mode_icon} ", ""),
         (persona.name, f"bold {persona.accent_color}"),
         (f"  {persona.age}세", "dim"),
         ("  ·  ", "dim"),
@@ -1874,6 +1925,7 @@ def _render_chat(console: Console, session: ConversationSession, assistant_typin
             is_read=is_read,
             persona_name=session.persona.name,
             accent=session.persona.accent_color,
+            avatar=_profile_avatar_text(session.persona),
         ))
     if assistant_typing:
         # Animated typing dots based on time
@@ -1929,6 +1981,7 @@ def _render_message(
     is_read: bool = True,
     persona_name: str = "",
     accent: str = "magenta",
+    avatar: str = "",
 ):
     bubble_width = min(width, max(24, int(width * 0.65)))
     timestamp = message.created_at.strftime("%H:%M")
@@ -1950,11 +2003,12 @@ def _render_message(
         )
     if message.role == "assistant":
         content = Text(display_text, style="white")
+        title_name = f"{avatar} {persona_name}".strip()
         return Align.left(
             Panel(
                 content,
                 border_style=accent,
-                title=f"[bold {accent}]{persona_name}[/bold {accent}]",
+                title=f"[bold {accent}]{title_name}[/bold {accent}]",
                 title_align="left",
                 subtitle=f"[dim]{timestamp}[/dim]",
                 subtitle_align="left",

--- a/src/girlfriend_generator/cli.py
+++ b/src/girlfriend_generator/cli.py
@@ -1644,6 +1644,12 @@ def _create_persona_wizard(console: "Console") -> Path | None:  # type: ignore[n
     console.print("\n  [bold]Extra Context[/bold]  [dim](optional, paste text or leave empty)[/dim]")
     console.print("  [dim]─────────────────────────────[/dim]")
     context_desc = _ask("Description or notes about this person", "")
+    profile_image_ref = _ask("Profile image URL/path (optional)", "")
+    profile_image_style = "real"
+    if profile_image_ref:
+        profile_image_style = _ask("Profile image style (real/anime/illustration)", "real")
+        if profile_image_style not in ("real", "anime", "illustration"):
+            profile_image_style = "real"
 
     # Build the persona JSON
     from .session_io import slugify
@@ -1661,6 +1667,16 @@ def _create_persona_wizard(console: "Console") -> Path | None:  # type: ignore[n
         "accent_color": accent_color,
         "provider_system_hint": f"{name}의 말투와 성격을 자연스럽게 유지한다.",
         "context_summary": context_desc if context_desc else f"{name}과(와)의 대화 시뮬레이션",
+        "profile_image": (
+            {
+                "url": profile_image_ref if profile_image_ref.startswith(("http://", "https://")) else "",
+                "source": "user_uploaded",
+                "cached_path": "" if profile_image_ref.startswith(("http://", "https://")) else profile_image_ref,
+                "style": profile_image_style,
+            }
+            if profile_image_ref
+            else None
+        ),
         "typing": {"min_seconds": 0.9, "max_seconds": 3.2},
         "nudge_policy": {
             "idle_after_seconds": 35,

--- a/src/girlfriend_generator/models.py
+++ b/src/girlfriend_generator/models.py
@@ -62,6 +62,14 @@ class InitiativeProfile:
 
 
 @dataclass(slots=True)
+class ProfileImage:
+    url: str = ""
+    source: str = "user_uploaded"  # auto_fetched, user_uploaded, generated
+    cached_path: str = ""
+    style: str = "real"  # real, anime, illustration
+
+
+@dataclass(slots=True)
 class ContextBundle:
     name: str
     age: int
@@ -90,6 +98,7 @@ class Persona:
     context_summary: str = ""
     core_personality: str = ""
     dynamic_personality_seed: str = ""
+    profile_image: ProfileImage | None = None
     style_profile: StyleProfile = field(default_factory=StyleProfile)
     initiative_profile: InitiativeProfile = field(default_factory=InitiativeProfile)
     evidence: list[ContextEvidence] = field(default_factory=list)

--- a/src/girlfriend_generator/persona_auto.py
+++ b/src/girlfriend_generator/persona_auto.py
@@ -31,6 +31,12 @@ Generate a persona with this EXACT JSON structure (respond with ONLY valid JSON,
   "accent_color": "magenta/cyan/yellow/green/red/blue (pick one that fits their vibe)",
   "provider_system_hint": "1 sentence in Korean — key personality note for the LLM",
   "context_summary": "1 sentence in Korean — overall relationship context",
+  "profile_image": {{
+    "url": "public image URL if confidently found, otherwise empty string",
+    "source": "auto_fetched",
+    "cached_path": "",
+    "style": "real/anime/illustration"
+  }},
   "typing": {{"min_seconds": 0.8, "max_seconds": 3.2}},
   "nudge_policy": {{
     "idle_after_seconds": 35,
@@ -61,6 +67,7 @@ Rules:
   with reasonable traits based on any clues in the input.
 - Make the personality VIVID and SPECIFIC — avoid generic "친절하고 밝은" descriptions.
 - Texting style should match the person/character (celebrity = busy, anime character = stylized, etc).
+- Include profile_image only when you have a likely public image URL; leave url empty if uncertain.
 - Korean text except for English names/words.
 """
 

--- a/src/girlfriend_generator/personas.py
+++ b/src/girlfriend_generator/personas.py
@@ -9,6 +9,7 @@ from .models import (
     InitiativeProfile,
     NudgePolicy,
     Persona,
+    ProfileImage,
     StyleProfile,
     TypingProfile,
 )
@@ -57,6 +58,7 @@ def persona_from_pack(payload: dict[str, Any]) -> Persona:
         or payload.get("relationship", {}).get("dynamic_personality", "")
         or payload.get("situation")
         or payload.get("summary", ""),
+        profile_image=_profile_image_from_payload(payload.get("profile_image")),
         style_profile=StyleProfile(
             **payload.get(
                 "style_profile",
@@ -91,6 +93,34 @@ def persona_from_pack(payload: dict[str, Any]) -> Persona:
     )
     persona.validate()
     return persona
+
+
+def _profile_image_from_payload(value: Any) -> ProfileImage | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        if value.startswith(("http://", "https://")):
+            return ProfileImage(url=value, source="user_uploaded")
+        return ProfileImage(cached_path=value, source="user_uploaded")
+    if not isinstance(value, dict):
+        raise ValueError("profile_image must be an object, URL/path string, or null.")
+
+    url = str(value.get("url", "") or "")
+    cached_path = str(value.get("cached_path", "") or value.get("path", "") or "")
+    source = str(value.get("source", "") or "user_uploaded")
+    style = str(value.get("style", "") or "real")
+    if source not in {"auto_fetched", "user_uploaded", "generated"}:
+        raise ValueError("profile_image.source must be auto_fetched, user_uploaded, or generated.")
+    if style not in {"real", "anime", "illustration"}:
+        raise ValueError("profile_image.style must be real, anime, or illustration.")
+    if not url and not cached_path:
+        return None
+    return ProfileImage(
+        url=url,
+        source=source,
+        cached_path=cached_path,
+        style=style,
+    )
 
 
 def _load_payload(path: Path) -> dict[str, Any]:

--- a/src/girlfriend_generator/session_io.py
+++ b/src/girlfriend_generator/session_io.py
@@ -36,6 +36,16 @@ def export_session(
             "interests": persona.interests,
             "soft_spots": persona.soft_spots,
             "boundaries": persona.boundaries,
+            "profile_image": (
+                {
+                    "url": persona.profile_image.url,
+                    "source": persona.profile_image.source,
+                    "cached_path": persona.profile_image.cached_path,
+                    "style": persona.profile_image.style,
+                }
+                if persona.profile_image is not None
+                else None
+            ),
             "style_profile": {
                 "warmth": persona.style_profile.warmth,
                 "teasing": persona.style_profile.teasing,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,9 @@ from girlfriend_generator.app import (
     _handle_command,
     _handle_key,
     _localized_relationship_label,
+    _profile_avatar_text,
     _render_header,
+    _render_message,
     _render_screen,
     _render_trace,
     _show_full_coach_panel,
@@ -18,8 +20,8 @@ from girlfriend_generator.app import (
     _sync_provider_trace,
     run_chat_app,
 )
-from girlfriend_generator.engine import ConversationSession
-from girlfriend_generator.models import ProviderReply, RuntimeTrace
+from girlfriend_generator.engine import ConversationSession, utc_now
+from girlfriend_generator.models import ChatMessage, ProfileImage, ProviderReply, RuntimeTrace
 from girlfriend_generator.personas import load_persona
 from girlfriend_generator.voice import DisabledVoiceInput, VoiceInputAdapter
 
@@ -225,6 +227,94 @@ def test_render_header_shows_current_relationship_at_top(monkeypatch) -> None:
 
     assert "결혼한 공동창업자" in rendered
     assert "같이 브랜드를 운영하면서 이미 결혼한 상태" in rendered
+
+
+def test_render_header_uses_initial_avatar_when_profile_image_missing(monkeypatch) -> None:
+    monkeypatch.setattr("girlfriend_generator.app.get_language", lambda: "ko")
+    persona = _load_test_persona()
+    persona.profile_image = None
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+
+    rendered = _render_to_text(_render_header(persona, session))
+
+    assert _profile_avatar_text(persona) in rendered
+
+
+def test_render_message_shows_profile_avatar_for_assistant() -> None:
+    persona = _load_test_persona()
+    persona.profile_image = ProfileImage(
+        url="https://example.com/wonyoung.jpg",
+        source="auto_fetched",
+        cached_path="personas/.images/wonyoung.jpg",
+        style="real",
+    )
+    message = ChatMessage(role="assistant", text="왔어?", created_at=utc_now())
+
+    rendered = _render_to_text(
+        _render_message(
+            message,
+            width=80,
+            persona_name=persona.name,
+            accent=persona.accent_color,
+            avatar=_profile_avatar_text(persona),
+        )
+    )
+
+    assert _profile_avatar_text(persona) in rendered
+    assert persona.name in rendered
+
+
+def test_profile_command_posts_image_metadata(tmp_path: Path) -> None:
+    persona = _load_test_persona()
+    persona.profile_image = ProfileImage(
+        url="https://example.com/wonyoung.jpg",
+        source="auto_fetched",
+        cached_path="personas/.images/wonyoung.jpg",
+        style="real",
+    )
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+
+    outcome = _handle_command(
+        text="/profile",
+        session=session,
+        provider=object(),
+        pending_job=None,
+        pending_delivery=None,
+        voice_input=DisabledVoiceInput(),
+        voice_output_available=False,
+        voice_output_enabled=False,
+        show_trace=True,
+        session_dir=tmp_path,
+    )
+
+    assert outcome["status_line"] == "Profile image posted."
+    assert "Profile Image" in session.messages[-1].text
+    assert "https://example.com/wonyoung.jpg" in session.messages[-1].text
+
+
+def test_profile_command_uses_default_avatar_when_image_missing(tmp_path: Path) -> None:
+    persona = _load_test_persona()
+    persona.profile_image = None
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+
+    _handle_command(
+        text="/profile",
+        session=session,
+        provider=object(),
+        pending_job=None,
+        pending_delivery=None,
+        voice_input=DisabledVoiceInput(),
+        voice_output_available=False,
+        voice_output_enabled=False,
+        show_trace=True,
+        session_dir=tmp_path,
+    )
+
+    assert "Default avatar" in session.messages[-1].text
+    assert _profile_avatar_text(persona) in session.messages[-1].text
 
 
 def test_render_trace_shows_coach_strength_and_weakness() -> None:

--- a/tests/test_personas.py
+++ b/tests/test_personas.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from girlfriend_generator.personas import discover_personas, load_persona
+from girlfriend_generator.personas import discover_personas, load_persona, persona_from_pack
 
 
 def test_discover_personas_lists_bundled_files() -> None:
@@ -19,3 +19,55 @@ def test_load_persona_validates_adult_and_nudges() -> None:
 
 def test_discover_personas_is_empty_for_missing_directory(tmp_path: Path) -> None:
     assert discover_personas(tmp_path / "missing") == []
+
+
+def test_persona_profile_image_dict_is_loaded() -> None:
+    persona = persona_from_pack(
+        {
+            "name": "미사키",
+            "age": 24,
+            "relationship_mode": "crush",
+            "background": "서울에서 일하는 성인 페르소나",
+            "situation": "서로 알아가는 중",
+            "texting_style": "짧고 장난스럽게",
+            "interests": ["영화"],
+            "soft_spots": ["기억해주기"],
+            "boundaries": ["무례함"],
+            "greeting": "왔어?",
+            "profile_image": {
+                "url": "https://example.com/misaki.png",
+                "source": "auto_fetched",
+                "cached_path": "personas/.images/misaki.png",
+                "style": "anime",
+            },
+            "nudge_policy": {"templates": ["왜 답장 안 해?"]},
+        }
+    )
+
+    assert persona.profile_image is not None
+    assert persona.profile_image.url == "https://example.com/misaki.png"
+    assert persona.profile_image.cached_path == "personas/.images/misaki.png"
+    assert persona.profile_image.style == "anime"
+
+
+def test_persona_profile_image_string_is_loaded_as_user_uploaded_path() -> None:
+    persona = persona_from_pack(
+        {
+            "name": "지은",
+            "age": 24,
+            "relationship_mode": "crush",
+            "background": "서울에서 일하는 성인 페르소나",
+            "situation": "서로 알아가는 중",
+            "texting_style": "짧고 장난스럽게",
+            "interests": ["고양이"],
+            "soft_spots": ["기억해주기"],
+            "boundaries": ["무례함"],
+            "greeting": "왔어?",
+            "profile_image": "~/Pictures/jieun.jpg",
+            "nudge_policy": {"templates": ["왜 답장 안 해?"]},
+        }
+    )
+
+    assert persona.profile_image is not None
+    assert persona.profile_image.cached_path == "~/Pictures/jieun.jpg"
+    assert persona.profile_image.source == "user_uploaded"


### PR DESCRIPTION
## Summary
- Add optional profile_image metadata to persona loading, manual creation, auto-generation prompts, and exported session persona metadata.
- Render terminal-safe avatar fallbacks in the chat header and assistant message titles.
- Add /profile to show configured image URL/cache/source/style metadata when full terminal image rendering is not available.
- Document the profile_image schema in personas/PERSONA_FORMAT.md.

## Close Policy
Refs #2

Not Closing Yet: this PR intentionally does not complete automatic download/caching, web image collection, bundled default artwork, or full iTerm2/Kitty/Sixel/chafa image rendering.

## Verification
- python3 -m pytest -q
- python3 -m pytest tests/test_personas.py tests/test_app.py -q