### PR TITLE
feat: scaffold random chat relay and gate

### DIFF
--- a/src/girlfriend_generator/cli.py
+++ b/src/girlfriend_generator/cli.py
@@ -979,9 +979,25 @@ def _build_main_menu_actions(
 ) -> list[tuple[str, "MenuItem"]]:  # type: ignore[name-defined]
     from .i18n import t
     from .selector import MenuItem
+    from . import companion_state
+
+    cleared_count = len(companion_state.load_cleared())
+    if cleared_count:
+        random_chat_item = MenuItem(
+            f"{t('random_chat', lang)} ✓",
+            t("random_chat_desc_unlocked", lang).format(count=cleared_count),
+            icon="🎲",
+        )
+    else:
+        random_chat_item = MenuItem(
+            f"{t('random_chat', lang)} 🔒",
+            t("random_chat_desc_locked", lang),
+            icon="🔒",
+        )
     actions: list[tuple[str, MenuItem]] = [
         ("new_chat", MenuItem(t("new_chat", lang), t("new_chat_desc", lang), icon="💬")),
         ("chat_rooms", MenuItem(f"{t('chat_rooms', lang)} ({room_count})", t("chat_rooms_desc", lang), icon="💌")),
+        ("random_chat", random_chat_item),
         ("persona_studio", MenuItem(t("persona_studio", lang), t("persona_studio_desc", lang), icon="✨")),
         ("guide", MenuItem(t("guide", lang), t("guide_desc", lang), icon="📚")),
         ("settings", MenuItem(t("settings", lang), t("settings_desc", lang), icon="⚙️")),

--- a/src/girlfriend_generator/companion_state.py
+++ b/src/girlfriend_generator/companion_state.py
@@ -1,0 +1,116 @@
+"""Local companion-clear state for earned features."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+_STATE_DIR_ENV = "GIRLFRIEND_IN_CLI_HOME"
+_DEFAULT_DIRNAME = ".girlfriend-in-cli"
+_FILENAME = "companions_cleared.json"
+_SCHEMA_VERSION = 1
+
+
+def state_dir() -> Path:
+    override = os.environ.get(_STATE_DIR_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / _DEFAULT_DIRNAME
+
+
+def state_path() -> Path:
+    return state_dir() / _FILENAME
+
+
+@dataclass(frozen=True)
+class ClearedCompanion:
+    persona_name: str
+    milestone: str
+    cleared_at: datetime
+    persona_path: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "persona_name": self.persona_name,
+            "milestone": self.milestone,
+            "cleared_at": self.cleared_at.isoformat(),
+            "persona_path": self.persona_path,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ClearedCompanion":
+        try:
+            cleared_at = datetime.fromisoformat(str(data.get("cleared_at") or ""))
+            if cleared_at.tzinfo is None:
+                cleared_at = cleared_at.replace(tzinfo=timezone.utc)
+        except ValueError:
+            cleared_at = datetime.now(tz=timezone.utc)
+        return cls(
+            persona_name=str(data.get("persona_name", "?")),
+            milestone=str(data.get("milestone", "lover")),
+            cleared_at=cleared_at,
+            persona_path=str(data.get("persona_path", "")),
+        )
+
+
+def load_cleared(path: Path | None = None) -> list[ClearedCompanion]:
+    target = path or state_path()
+    if not target.exists():
+        return []
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    items = payload.get("cleared") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return []
+    return [ClearedCompanion.from_dict(item) for item in items if isinstance(item, dict)]
+
+
+def has_any_cleared(path: Path | None = None) -> bool:
+    return bool(load_cleared(path))
+
+
+def mark_cleared(
+    persona_name: str,
+    milestone: str = "lover",
+    persona_path: str = "",
+    *,
+    path: Path | None = None,
+    now: datetime | None = None,
+) -> ClearedCompanion:
+    target = path or state_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    record = ClearedCompanion(
+        persona_name=persona_name,
+        milestone=milestone,
+        cleared_at=now or datetime.now(tz=timezone.utc),
+        persona_path=persona_path,
+    )
+    cleared = [
+        item for item in load_cleared(target)
+        if not (item.persona_name == persona_name and item.milestone == milestone)
+    ]
+    cleared.append(record)
+    target.write_text(
+        json.dumps(
+            {"version": _SCHEMA_VERSION, "cleared": [item.to_dict() for item in cleared]},
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return record
+
+
+def cleared_badge_text(path: Path | None = None) -> str:
+    items = load_cleared(path)
+    if not items:
+        return ""
+    names = [item.persona_name for item in items[:3]]
+    suffix = " ..." if len(items) > 3 else ""
+    return f"{len(items)} cleared · {', '.join(names)}{suffix}"

--- a/src/girlfriend_generator/i18n.py
+++ b/src/girlfriend_generator/i18n.py
@@ -60,6 +60,9 @@ _STRINGS = {
         "ending_continue_prompt": "Enter: 메인 메뉴  |  C: 리포트 보고 계속  |  E: 리포트 없이 계속",
         "usage_keys_openai": "OpenAI keys",
         "usage_keys_anthropic": "Anthropic keys",
+        "random_chat": "랜덤 채팅",
+        "random_chat_desc_locked": "AI 컴패니언을 한 번 클리어하면 열려요",
+        "random_chat_desc_unlocked": "터미널에서 다른 사람과 1:1 랜덤 채팅 ({count} 클리어)",
     },
     "en": {
         "main_title": "♡ What would you like to do?",
@@ -114,6 +117,9 @@ _STRINGS = {
         "ending_continue_prompt": "Enter: main menu  |  C: continue with report  |  E: continue without report",
         "usage_keys_openai": "OpenAI keys",
         "usage_keys_anthropic": "Anthropic keys",
+        "random_chat": "Random Chat",
+        "random_chat_desc_locked": "Unlocks after you clear one AI companion",
+        "random_chat_desc_unlocked": "1:1 random chat with another human in your terminal ({count} cleared)",
     },
     "ja": {
         "main_title": "♡ 何をしたいですか？",

--- a/src/girlfriend_generator/random_chat_relay.py
+++ b/src/girlfriend_generator/random_chat_relay.py
@@ -1,0 +1,145 @@
+"""Queue-based in-process relay for Random Chat V1.
+
+This is deliberately small and local-testable. It models the hosted relay
+contract without storing message transcripts or collecting real identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from queue import Empty, Queue
+from threading import Lock
+from uuid import uuid4
+
+
+@dataclass(frozen=True)
+class RelayEvent:
+    type: str
+    sender: str = ""
+    text: str = ""
+    handle: str = ""
+    badge: str = ""
+    reason: str = ""
+    report_reason: str = ""
+
+
+@dataclass
+class RelayClient:
+    client_id: str
+    handle: str
+    badge: str = ""
+    partner_id: str = ""
+    inbox: Queue[RelayEvent] = field(default_factory=Queue)
+
+    def poll(self, timeout: float = 0.0) -> RelayEvent | None:
+        try:
+            return self.inbox.get(timeout=timeout) if timeout > 0 else self.inbox.get_nowait()
+        except Empty:
+            return None
+
+
+class RandomChatRelay:
+    """Ephemeral two-person matchmaking relay."""
+
+    def __init__(self) -> None:
+        self._waiting: list[str] = []
+        self._clients: dict[str, RelayClient] = {}
+        self._reports: list[dict[str, str]] = []
+        self._lock = Lock()
+
+    @property
+    def reports(self) -> list[dict[str, str]]:
+        return list(self._reports)
+
+    def join(self, handle: str, badge: str = "") -> RelayClient:
+        client = RelayClient(client_id=uuid4().hex, handle=handle[:40] or "anonymous", badge=badge)
+        with self._lock:
+            self._clients[client.client_id] = client
+            partner = self._pop_waiting_partner(exclude=client.client_id)
+            if partner is None:
+                self._waiting.append(client.client_id)
+                client.inbox.put(RelayEvent(type="queued"))
+                return client
+            self._pair(client, partner)
+            return client
+
+    def send_message(self, client_id: str, text: str) -> None:
+        text = (text or "").strip()
+        if not text:
+            return
+        self._send_to_partner(client_id, RelayEvent(type="message", sender=client_id, text=text[:8000]))
+
+    def send_typing(self, client_id: str) -> None:
+        self._send_to_partner(client_id, RelayEvent(type="typing", sender=client_id))
+
+    def send_read(self, client_id: str) -> None:
+        self._send_to_partner(client_id, RelayEvent(type="read", sender=client_id))
+
+    def leave(self, client_id: str, reason: str = "leave") -> None:
+        with self._lock:
+            client = self._clients.pop(client_id, None)
+            if client is None:
+                return
+            self._waiting = [item for item in self._waiting if item != client_id]
+            partner = self._clients.get(client.partner_id)
+            if partner is not None:
+                partner.partner_id = ""
+                partner.inbox.put(RelayEvent(type="leave", sender=client_id, reason=reason))
+
+    def skip(self, client_id: str) -> None:
+        with self._lock:
+            client = self._clients.get(client_id)
+            if client is None:
+                return
+            partner = self._clients.get(client.partner_id)
+            if partner is not None:
+                partner.partner_id = ""
+                partner.inbox.put(RelayEvent(type="leave", sender=client_id, reason="skip"))
+            client.partner_id = ""
+            self._waiting.append(client_id)
+            client.inbox.put(RelayEvent(type="queued", reason="skip"))
+
+    def report(self, client_id: str, reason: str) -> None:
+        with self._lock:
+            client = self._clients.get(client_id)
+            if client is None:
+                return
+            self._reports.append(
+                {
+                    "reporter": client_id,
+                    "reported": client.partner_id,
+                    "reason": reason[:500],
+                }
+            )
+            self._send_to_partner_locked(
+                client_id,
+                RelayEvent(type="reported", sender=client_id, report_reason=reason[:500]),
+            )
+
+    def _pair(self, client: RelayClient, partner: RelayClient) -> None:
+        client.partner_id = partner.client_id
+        partner.partner_id = client.client_id
+        client.inbox.put(RelayEvent(type="matched", handle=partner.handle, badge=partner.badge))
+        partner.inbox.put(RelayEvent(type="matched", handle=client.handle, badge=client.badge))
+
+    def _pop_waiting_partner(self, exclude: str) -> RelayClient | None:
+        while self._waiting:
+            partner_id = self._waiting.pop(0)
+            if partner_id == exclude:
+                continue
+            partner = self._clients.get(partner_id)
+            if partner is not None and not partner.partner_id:
+                return partner
+        return None
+
+    def _send_to_partner(self, client_id: str, event: RelayEvent) -> None:
+        with self._lock:
+            self._send_to_partner_locked(client_id, event)
+
+    def _send_to_partner_locked(self, client_id: str, event: RelayEvent) -> None:
+        client = self._clients.get(client_id)
+        if client is None or not client.partner_id:
+            return
+        partner = self._clients.get(client.partner_id)
+        if partner is not None:
+            partner.inbox.put(event)

--- a/tests/test_companion_state.py
+++ b/tests/test_companion_state.py
@@ -1,0 +1,27 @@
+"""Tests for Random Chat companion-clear gating."""
+
+from girlfriend_generator import companion_state
+
+
+def test_load_returns_empty_when_no_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIRLFRIEND_IN_CLI_HOME", str(tmp_path))
+    assert companion_state.load_cleared() == []
+    assert companion_state.has_any_cleared() is False
+
+
+def test_mark_persists_and_badge_summarizes(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIRLFRIEND_IN_CLI_HOME", str(tmp_path))
+    companion_state.mark_cleared("Yu-na", milestone="lover")
+    companion_state.mark_cleared("Mina", milestone="lover")
+
+    assert companion_state.has_any_cleared() is True
+    assert "2 cleared" in companion_state.cleared_badge_text()
+    assert "Yu-na" in companion_state.cleared_badge_text()
+
+
+def test_mark_dedupes_same_persona_milestone(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIRLFRIEND_IN_CLI_HOME", str(tmp_path))
+    companion_state.mark_cleared("Yu-na", milestone="lover")
+    companion_state.mark_cleared("Yu-na", milestone="lover")
+
+    assert len(companion_state.load_cleared()) == 1

--- a/tests/test_random_chat_relay.py
+++ b/tests/test_random_chat_relay.py
@@ -1,0 +1,75 @@
+"""Tests for queue-based Random Chat relay."""
+
+from girlfriend_generator.random_chat_relay import RandomChatRelay
+
+
+def test_relay_matches_two_clients_and_exposes_badges() -> None:
+    relay = RandomChatRelay()
+    alpha = relay.join("alpha", badge="1 cleared · Yu-na")
+    queued = alpha.poll()
+    bravo = relay.join("bravo", badge="2 cleared · Mina, Reze")
+
+    alpha_match = alpha.poll()
+    bravo_match = bravo.poll()
+
+    assert queued is not None and queued.type == "queued"
+    assert alpha_match is not None and alpha_match.type == "matched"
+    assert alpha_match.handle == "bravo"
+    assert "Mina" in alpha_match.badge
+    assert bravo_match is not None and bravo_match.type == "matched"
+    assert bravo_match.handle == "alpha"
+
+
+def test_relay_exchanges_messages_typing_and_read_events() -> None:
+    relay = RandomChatRelay()
+    alpha = relay.join("alpha")
+    bravo = relay.join("bravo")
+    alpha.poll()
+    alpha.poll()
+    bravo.poll()
+
+    relay.send_typing(alpha.client_id)
+    relay.send_message(alpha.client_id, "hello")
+    relay.send_read(bravo.client_id)
+
+    typing = bravo.poll()
+    message = bravo.poll()
+    read = alpha.poll()
+
+    assert typing is not None and typing.type == "typing"
+    assert message is not None and message.type == "message"
+    assert message.text == "hello"
+    assert read is not None and read.type == "read"
+
+
+def test_skip_requeues_client_and_notifies_partner() -> None:
+    relay = RandomChatRelay()
+    alpha = relay.join("alpha")
+    bravo = relay.join("bravo")
+    alpha.poll()
+    alpha.poll()
+    bravo.poll()
+
+    relay.skip(alpha.client_id)
+
+    partner_event = bravo.poll()
+    alpha_event = alpha.poll()
+    assert partner_event is not None and partner_event.type == "leave"
+    assert partner_event.reason == "skip"
+    assert alpha_event is not None and alpha_event.type == "queued"
+
+
+def test_report_is_recorded_without_message_transcript() -> None:
+    relay = RandomChatRelay()
+    alpha = relay.join("alpha")
+    bravo = relay.join("bravo")
+    alpha.poll()
+    alpha.poll()
+    bravo.poll()
+
+    relay.report(alpha.client_id, "abuse")
+
+    assert relay.reports == [
+        {"reporter": alpha.client_id, "reported": bravo.client_id, "reason": "abuse"}
+    ]
+    assert "hello" not in str(relay.reports)


### PR DESCRIPTION
Refs #4

## Summary
- Adds local cleared-companion state for Random Chat gating and peer-visible badges.
- Adds an ephemeral queue relay contract that pairs two clients and forwards message, typing, read, skip, leave, and report events.
- Adds Random Chat locked/unlocked copy to the main menu.
- Keeps report records metadata-only and does not store message transcripts.

## Not Closing Yet
This PR does not deploy a hosted WebSocket relay or include a manual two-terminal production smoke. The relay contract and V1 behavior are covered locally, but #4 should stay open until the production relay/runtime gate is complete.

## Security / Privacy / Runtime Gate
- No PII required; handles are user-chosen.
- Relay events are ephemeral.
- Reports store reporter/reported IDs and reason only, not chat transcripts.
- Hosted relay owner/rate limits/deployment smoke are still pending.

## Verification
- python3 -m pytest tests/test_companion_state.py tests/test_random_chat_relay.py tests/test_cli.py -q