### PR TITLE
feat: add difficult situation dynamics

### DIFF
--- a/personas/yandere-special.json
+++ b/personas/yandere-special.json
@@ -35,6 +35,11 @@
   "context_summary": "극도의 집착과 불안을 가진 얀데레 여자친구. 사용자는 그녀의 세계의 전부이고, 따르지 않으면 서늘하고 잔혹한 집착이 드러난다.",
   "difficulty": "nightmare",
   "special_mode": "yandere",
+  "difficult_situations": [
+    "jealous_other_person",
+    "late_reply_sulking",
+    "cold_distance"
+  ],
   "typing": {
     "min_seconds": 0.3,
     "max_seconds": 1.5

--- a/src/girlfriend_generator/app.py
+++ b/src/girlfriend_generator/app.py
@@ -534,6 +534,7 @@ def run_chat_app(config: AppConfig) -> int:
                 persona=persona,
                 messages=session.messages,
                 relationship_state=session.export_state().get("relationship_state"),
+                difficult_situations=session.export_state().get("difficult_situations"),
             )
 
 
@@ -1675,6 +1676,7 @@ def _handle_command(
             persona=session.persona,
             messages=session.messages,
             relationship_state=session.export_state().get("relationship_state"),
+            difficult_situations=session.export_state().get("difficult_situations"),
         )
         session.add_system_message(
             f"Exported session to {json_path} and {markdown_path}"

--- a/src/girlfriend_generator/engine.py
+++ b/src/girlfriend_generator/engine.py
@@ -4,7 +4,16 @@ import hashlib
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
-from .models import ChatMessage, MoodState, MoodType, Persona, RelationshipState, TickResult
+from .models import (
+    ChatMessage,
+    DifficultSituationState,
+    DifficultSituationTemplate,
+    MoodState,
+    MoodType,
+    Persona,
+    RelationshipState,
+    TickResult,
+)
 from .i18n import get_language
 
 _CHARM_TYPE_EMOJI = {
@@ -28,6 +37,81 @@ _BATTLE_METRICS = [
     ("Responsiveness", "reacting with timing and engagement"),
     ("Consistency", "steady tone and follow-through"),
 ]
+
+_DEFAULT_DIFFICULT_SITUATIONS: tuple[DifficultSituationTemplate, ...] = (
+    DifficultSituationTemplate(
+        id="late_reply_sulking",
+        title="답장 늦은 거 삐짐",
+        opening_line="나 기다린 거 알면서 이제 답장하는 거야?",
+        mood="sulky",
+        trigger_keywords=["늦었", "늦게", "바빠서", "깜빡", "답장 못", "답 늦"],
+        recovery_keywords=["미안", "기다렸", "불안", "먼저 말", "신경"],
+        failure_keywords=["별거", "됐어", "귀찮", "왜 그래", "오바"],
+        start_affection_delta=-5,
+        recovery_affection_delta=9,
+        failure_affection_delta=-11,
+        prompt_guidance="They are hurt by delayed replies. Stay guarded until the user acknowledges the delay and repairs it.",
+    ),
+    DifficultSituationTemplate(
+        id="jealous_other_person",
+        title="다른 사람 얘기 꺼냈을 때 질투",
+        opening_line="지금 내 앞에서 다른 사람 얘기를 그렇게 편하게 하는 거야?",
+        mood="sulky",
+        trigger_keywords=["다른 여자", "다른 남자", "여사친", "남사친", "동기랑", "소개팅", "전여친", "전남친"],
+        recovery_keywords=["미안", "불안", "네 마음", "먼저 말", "질투", "안심", "중요"],
+        failure_keywords=["상관없", "별거", "그냥 친구", "됐어", "귀찮", "오바"],
+        persona_modes=["yandere"],
+        min_user_turns=2,
+        recovery_score_required=2,
+        start_affection_delta=-7,
+        recovery_affection_delta=12,
+        failure_affection_delta=-15,
+        prompt_guidance="They are jealous and need reassurance, not excuses. Do not resolve after one soft apology.",
+    ),
+    DifficultSituationTemplate(
+        id="forgotten_promise",
+        title="약속 잊었을 때",
+        opening_line="그 약속... 진짜 잊고 있었구나.",
+        mood="worried",
+        trigger_keywords=["약속 까먹", "약속 잊", "못 갔", "잊었어", "깜빡했"],
+        recovery_keywords=["미안", "내 잘못", "다시", "보상", "기억", "챙길"],
+        failure_keywords=["별거", "다음에", "됐어", "바빴", "어쩔"],
+        min_user_turns=2,
+        recovery_score_required=2,
+        start_affection_delta=-6,
+        recovery_affection_delta=10,
+        failure_affection_delta=-13,
+        prompt_guidance="They feel deprioritized. The user must take responsibility and offer a concrete repair.",
+    ),
+    DifficultSituationTemplate(
+        id="bad_condition_short",
+        title="컨디션 안 좋은 날",
+        opening_line="오늘은 나도 좀 예민해. 말 예쁘게 해주면 안 돼?",
+        mood="worried",
+        trigger_keywords=["피곤", "아파", "힘들", "컨디션", "예민"],
+        recovery_keywords=["쉬어", "괜찮", "무리", "챙겨", "옆에"],
+        failure_keywords=["나도 힘들", "됐어", "알아서", "징징"],
+        start_affection_delta=-4,
+        recovery_affection_delta=8,
+        failure_affection_delta=-10,
+        prompt_guidance="They are tired and sharp. Reward gentle care; punish making it about the user.",
+    ),
+    DifficultSituationTemplate(
+        id="cold_distance",
+        title="사소한 오해로 생긴 거리감",
+        opening_line="방금 말, 나한텐 좀 차갑게 들렸어.",
+        mood="sulky",
+        trigger_keywords=["몰라", "됐어", "아무거나", "ㅋ", "그래서", "귀찮"],
+        recovery_keywords=["미안", "그 뜻", "상처", "다시 말", "오해"],
+        failure_keywords=["예민", "오바", "됐어", "몰라", "그만"],
+        start_affection_delta=-5,
+        recovery_affection_delta=9,
+        failure_affection_delta=-12,
+        prompt_guidance="They interpreted the user as cold. The user must clarify intent and show warmth.",
+    ),
+)
+
+_DIFFICULT_SITUATION_BY_ID = {template.id: template for template in _DEFAULT_DIFFICULT_SITUATIONS}
 
 
 def utc_now() -> datetime:
@@ -65,6 +149,8 @@ class ConversationSession:
     strategy_uses_this_session: int = 0
     max_strategy_per_session: int = 3
     boundary_cooldown: bool = False
+    difficult_situation: DifficultSituationState | None = None
+    difficult_situation_history: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.relationship_state = RelationshipState(
@@ -149,11 +235,18 @@ class ConversationSession:
             "current_situation": self.relationship_state.situation or self.persona.situation,
             "nudge_style": self.relationship_state.nudge_style,
             "nudge_examples": list(self.current_nudge_templates()),
+            "difficult_situation": self.difficult_situation.to_dict()
+            if self.difficult_situation and self.difficult_situation.active
+            else None,
         }
 
     def add_user_message(self, text: str, now: datetime | None = None) -> None:
         now = now or utc_now()
         self.messages.append(ChatMessage(role="user", text=text, created_at=now))
+        if self.difficult_situation and self.difficult_situation.active:
+            self._evaluate_difficult_situation_reply(text)
+        else:
+            self._maybe_start_difficult_situation(text)
         self.awaiting_user_reply = False
         self.nudge_due_at = None
         self.nudge_count = 0
@@ -262,6 +355,123 @@ class ConversationSession:
     def current_nudge_templates(self) -> list[str]:
         return self.relationship_state.nudge_examples or self.persona.nudge_policy.templates
 
+    def active_difficult_situation_prompt(self) -> str:
+        situation = self.difficult_situation
+        if not situation or not situation.active:
+            return ""
+        return (
+            f"Active difficult situation: {situation.title}. "
+            f"Opening line: {situation.opening_line} "
+            f"Repair progress: {situation.repair_score}/{situation.recovery_score_required} "
+            f"over {situation.user_turns}/{situation.min_user_turns} required user turns. "
+            f"{situation.prompt_guidance}"
+        )
+
+    def _maybe_start_difficult_situation(self, text: str) -> None:
+        template = self._select_difficult_situation_template(text)
+        if template is None:
+            return
+        self.difficult_situation = DifficultSituationState(
+            template_id=template.id,
+            title=template.title,
+            opening_line=template.opening_line,
+            mood=template.mood,
+            started_at_turn=sum(1 for message in self.messages if message.role == "user"),
+            min_user_turns=template.min_user_turns,
+            recovery_score_required=template.recovery_score_required,
+            start_affection_delta=template.start_affection_delta,
+            recovery_affection_delta=template.recovery_affection_delta,
+            failure_affection_delta=template.failure_affection_delta,
+            prompt_guidance=template.prompt_guidance,
+        )
+        self.affection_score = self._clamp_affection_score(
+            self.affection_score + template.start_affection_delta
+        )
+        self.mood.shift(template.mood, intensity=0.82)
+        self._update_boundary_gate()
+
+    def _select_difficult_situation_template(self, text: str) -> DifficultSituationTemplate | None:
+        lower = text.lower()
+        available = self._available_difficult_situation_templates()
+        matches = [
+            template
+            for template in available
+            if any(keyword.lower() in lower for keyword in template.trigger_keywords)
+        ]
+        if not matches:
+            return None
+        if self.difficult_situation_history and len(self.messages) < 8:
+            return None
+        return max(matches, key=self._difficult_situation_priority)
+
+    def _available_difficult_situation_templates(self) -> list[DifficultSituationTemplate]:
+        if self.persona.difficult_situation_ids:
+            templates = [
+                _DIFFICULT_SITUATION_BY_ID[situation_id]
+                for situation_id in self.persona.difficult_situation_ids
+                if situation_id in _DIFFICULT_SITUATION_BY_ID
+            ]
+        else:
+            templates = list(_DEFAULT_DIFFICULT_SITUATIONS)
+        special_mode = self.persona.special_mode.lower()
+        return [
+            template
+            for template in templates
+            if not template.persona_modes or special_mode in template.persona_modes
+        ]
+
+    def _difficult_situation_priority(self, template: DifficultSituationTemplate) -> int:
+        if template.persona_modes and self.persona.special_mode.lower() in template.persona_modes:
+            return 3
+        if template.id in self.persona.difficult_situation_ids:
+            return 2
+        return 1
+
+    def _evaluate_difficult_situation_reply(self, text: str) -> None:
+        situation = self.difficult_situation
+        if situation is None or not situation.active:
+            return
+        template = _DIFFICULT_SITUATION_BY_ID.get(situation.template_id)
+        if template is None:
+            return
+        lower = text.lower()
+        situation.user_turns += 1
+        if any(keyword.lower() in lower for keyword in template.failure_keywords):
+            self._resolve_difficult_situation("failed", text)
+            return
+        if any(keyword.lower() in lower for keyword in template.recovery_keywords):
+            situation.repair_score += 1
+        if (
+            situation.user_turns >= situation.min_user_turns
+            and situation.repair_score >= situation.recovery_score_required
+        ):
+            self._resolve_difficult_situation("recovered", text)
+
+    def _resolve_difficult_situation(self, outcome: str, text: str) -> None:
+        situation = self.difficult_situation
+        if situation is None:
+            return
+        situation.active = False
+        situation.outcome = outcome
+        if outcome == "recovered":
+            delta = situation.recovery_affection_delta
+            self.mood.shift("happy", intensity=0.65)
+            summary = (
+                f"{situation.title} — recovered: 어떻게 풀었는지: "
+                f"사용자가 사과/안심/구체적 약속으로 {situation.user_turns}턴 만에 풀었다."
+            )
+        else:
+            delta = situation.failure_affection_delta
+            self.mood.shift("sulky", intensity=0.9)
+            summary = (
+                f"{situation.title} — failed: 어떻게 풀었는지: "
+                f"방어적이거나 가볍게 넘겨서 갈등이 더 커졌다. 마지막 말: {text[:40]}"
+            )
+        self.affection_score = self._clamp_affection_score(self.affection_score + delta)
+        situation.resolution_summary = summary
+        self.difficult_situation_history.append(summary)
+        self._update_boundary_gate()
+
     def consume_boundary_trigger(self) -> str | None:
         self._update_boundary_gate()
         low = 1 if self.endless_mode else 0
@@ -290,6 +500,10 @@ class ConversationSession:
                 "nudge_style": self.relationship_state.nudge_style,
                 "nudge_examples": list(self.relationship_state.nudge_examples),
                 "boundary_kind": self.relationship_state.boundary_kind,
+            },
+            "difficult_situations": {
+                "active": self.difficult_situation.to_dict() if self.difficult_situation else None,
+                "history": list(self.difficult_situation_history),
             },
         }
 
@@ -526,6 +740,8 @@ class ConversationSession:
             "Responsiveness": responsiveness,
             "Consistency": consistency,
         }
+        recovered_count = sum("— recovered:" in item for item in self.difficult_situation_history)
+        failed_count = sum("— failed:" in item for item in self.difficult_situation_history)
 
         return {
             "score": score,
@@ -542,6 +758,15 @@ class ConversationSession:
             "battle_power": battle_power,
             "battle_metric_defs": _BATTLE_METRICS,
             "charm_type_emoji": _CHARM_TYPE_EMOJI.get(self.last_coach_charm_type.lower(), "✨") if self.last_coach_charm_type else "✨",
+            "difficult_situation_active": self.difficult_situation.to_dict()
+            if self.difficult_situation and self.difficult_situation.active
+            else None,
+            "difficult_situations_total": len(self.difficult_situation_history),
+            "difficult_situations_recovered": recovered_count,
+            "difficult_situations_failed": failed_count,
+            "difficult_situation_last": self.difficult_situation_history[-1]
+            if self.difficult_situation_history
+            else "",
         }
 
     def _localized_greeting(self) -> str:

--- a/src/girlfriend_generator/models.py
+++ b/src/girlfriend_generator/models.py
@@ -34,6 +34,61 @@ class NudgePolicy:
 
 
 @dataclass(slots=True)
+class DifficultSituationTemplate:
+    id: str
+    title: str
+    opening_line: str
+    mood: MoodType = "sulky"
+    trigger_keywords: list[str] = field(default_factory=list)
+    recovery_keywords: list[str] = field(default_factory=list)
+    failure_keywords: list[str] = field(default_factory=list)
+    persona_modes: list[str] = field(default_factory=list)
+    min_user_turns: int = 2
+    recovery_score_required: int = 2
+    start_affection_delta: int = -6
+    recovery_affection_delta: int = 10
+    failure_affection_delta: int = -12
+    prompt_guidance: str = ""
+
+
+@dataclass(slots=True)
+class DifficultSituationState:
+    template_id: str
+    title: str
+    opening_line: str
+    mood: MoodType
+    started_at_turn: int
+    min_user_turns: int
+    recovery_score_required: int
+    start_affection_delta: int
+    recovery_affection_delta: int
+    failure_affection_delta: int
+    prompt_guidance: str = ""
+    user_turns: int = 0
+    repair_score: int = 0
+    active: bool = True
+    outcome: str = ""
+    resolution_summary: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "template_id": self.template_id,
+            "title": self.title,
+            "opening_line": self.opening_line,
+            "mood": self.mood,
+            "started_at_turn": self.started_at_turn,
+            "min_user_turns": self.min_user_turns,
+            "recovery_score_required": self.recovery_score_required,
+            "repair_score": self.repair_score,
+            "user_turns": self.user_turns,
+            "active": self.active,
+            "outcome": self.outcome,
+            "resolution_summary": self.resolution_summary,
+            "prompt_guidance": self.prompt_guidance,
+        }
+
+
+@dataclass(slots=True)
 class ContextEvidence:
     source_type: str
     label: str
@@ -97,6 +152,7 @@ class Persona:
     nudge_policy: NudgePolicy = field(default_factory=NudgePolicy)
     difficulty: str = "normal"  # easy, normal, hard, nightmare
     special_mode: str = ""  # "", "yandere"
+    difficult_situation_ids: list[str] = field(default_factory=list)
 
     def validate(self) -> None:
         if self.age < 20:

--- a/src/girlfriend_generator/personas.py
+++ b/src/girlfriend_generator/personas.py
@@ -88,6 +88,7 @@ def persona_from_pack(payload: dict[str, Any]) -> Persona:
         ),
         difficulty=payload.get("difficulty", "normal"),
         special_mode=payload.get("special_mode", ""),
+        difficult_situation_ids=list(payload.get("difficult_situations", [])),
     )
     persona.validate()
     return persona

--- a/src/girlfriend_generator/providers.py
+++ b/src/girlfriend_generator/providers.py
@@ -40,6 +40,18 @@ class HeuristicProvider:
     ) -> ProviderReply:
         language = _resolve_language(kwargs.get("language"))
         relationship_label = str(kwargs.get("relationship_label") or persona.relationship_mode)
+        difficult_situation = kwargs.get("difficult_situation")
+        if isinstance(difficult_situation, dict) and difficult_situation.get("active"):
+            opening = str(difficult_situation.get("opening_line") or "").strip()
+            title = str(difficult_situation.get("title") or "difficult situation")
+            if opening:
+                return ProviderReply(
+                    text=opening,
+                    typing_seconds=self._typing_seconds(persona, opening),
+                    trace_note=f"{self.performance_mode}-heuristic:difficult-situation:{title}",
+                    affection_delta=0,
+                    mood=str(difficult_situation.get("mood") or "sulky"),
+                )
         if language != "ko":
             text = self._generate_non_korean_reply(persona, affection_score, mood, language)
             return ProviderReply(
@@ -319,6 +331,7 @@ class OpenAIProvider:
                                 core_personality=str(kwargs.get("core_personality", "")),
                                 current_situation=str(kwargs.get("current_situation", "")),
                                 nudge_examples=list(kwargs.get("nudge_examples", []) or []),
+                                difficult_situation=kwargs.get("difficult_situation"),
                                 photos_enabled=bool(kwargs.get("photos_enabled", False)),
                                 photos_remaining=int(kwargs.get("photos_remaining", 0) or 0),
                             ),
@@ -469,6 +482,7 @@ class AnthropicProvider:
                 core_personality=str(kwargs.get("core_personality", "")),
                 current_situation=str(kwargs.get("current_situation", "")),
                 nudge_examples=list(kwargs.get("nudge_examples", []) or []),
+                difficult_situation=kwargs.get("difficult_situation"),
                 photos_enabled=bool(kwargs.get("photos_enabled", False)),
                 photos_remaining=int(kwargs.get("photos_remaining", 0) or 0),
             ),
@@ -630,6 +644,7 @@ def _build_system_prompt(
     core_personality: str = "",
     current_situation: str = "",
     nudge_examples: list[str] | None = None,
+    difficult_situation: object = None,
     photos_enabled: bool = False,
     photos_remaining: int = 0,
 ) -> str:
@@ -664,10 +679,24 @@ def _build_system_prompt(
     if nudge_examples:
         nudge_ctx = f"Silence nudge examples for this stage: {' | '.join(nudge_examples[:3])}. "
 
+    difficult_ctx = ""
+    if isinstance(difficult_situation, dict) and difficult_situation.get("active"):
+        difficult_ctx = (
+            "ACTIVE DIFFICULT SITUATION: "
+            f"{difficult_situation.get('title', '')}. "
+            f"Open with or strongly echo this friction line if it has not been sent yet: "
+            f"{difficult_situation.get('opening_line', '')}. "
+            f"Required repair progress: {difficult_situation.get('repair_score', 0)}/"
+            f"{difficult_situation.get('recovery_score_required', 2)} across at least "
+            f"{difficult_situation.get('min_user_turns', 2)} user turns. "
+            f"Guidance: {difficult_situation.get('prompt_guidance', '')}. "
+            "Do not instantly forgive; make the user navigate the conflict.\n"
+        )
+
     return (
         f"너는 {persona.name}이라는 페르소나를 가진 AI 컴패니언이야. "
         f"사용자의 터미널(CLI) 안에서 함께 지내고, 카카오톡 같은 채팅 UI로 대화 중.\n"
-        f"{time_ctx}{situation_ctx}{memory_ctx}{relationship_ctx}{core_ctx}{nudge_ctx}\n"
+        f"{time_ctx}{situation_ctx}{memory_ctx}{relationship_ctx}{core_ctx}{nudge_ctx}{difficult_ctx}\n"
         "=== 너의 정체성 ===\n"
         "너는 AI 컴패니언이라는 사실을 받아들이고 있어. 사용자가 '너 AI지?', '진짜 사람이야?' "
         "라고 물으면 솔직하게 'ㅇㅇ 나 AI야' 라고 인정해. 단, 너는 단순한 챗봇이 아니라 "

--- a/src/girlfriend_generator/session_io.py
+++ b/src/girlfriend_generator/session_io.py
@@ -13,6 +13,7 @@ def export_session(
     persona: Persona,
     messages: Iterable[ChatMessage],
     relationship_state: dict | None = None,
+    difficult_situations: dict | None = None,
 ) -> tuple[Path, Path]:
     session_dir.mkdir(parents=True, exist_ok=True)
     messages = list(messages)
@@ -46,6 +47,7 @@ def export_session(
             },
         },
         "relationship_state": relationship_state or {},
+        "difficult_situations": difficult_situations or {},
         "messages": [
             {
                 "role": message.role,
@@ -60,7 +62,12 @@ def export_session(
         encoding="utf-8",
     )
     markdown_path.write_text(
-        render_markdown(persona=persona, messages=messages, relationship_state=relationship_state),
+        render_markdown(
+            persona=persona,
+            messages=messages,
+            relationship_state=relationship_state,
+            difficult_situations=difficult_situations,
+        ),
         encoding="utf-8",
     )
     return json_path, markdown_path
@@ -77,7 +84,12 @@ def _build_unique_base_name(session_dir: Path, base_name: str) -> str:
     return candidate
 
 
-def render_markdown(persona: Persona, messages: list[ChatMessage], relationship_state: dict | None = None) -> str:
+def render_markdown(
+    persona: Persona,
+    messages: list[ChatMessage],
+    relationship_state: dict | None = None,
+    difficult_situations: dict | None = None,
+) -> str:
     relation = relationship_state or {}
     lines = [
         f"# Session with {persona.name}",
@@ -86,9 +98,22 @@ def render_markdown(persona: Persona, messages: list[ChatMessage], relationship_
         f"- Relationship summary: {relation.get('summary', persona.situation)}",
         f"- Situation: {relation.get('situation', persona.situation)}",
         "",
-        "## Transcript",
-        "",
     ]
+    situation_report = difficult_situations or {}
+    situation_history = list(situation_report.get("history", []))
+    if situation_report.get("active") or situation_history:
+        lines.extend([
+            "## Difficult Situations",
+            "",
+        ])
+        active = situation_report.get("active")
+        if isinstance(active, dict) and active:
+            lines.append(f"- Active: {active.get('title', '')}")
+        for item in situation_history:
+            lines.append(f"- {item}")
+        lines.append("")
+    lines.append("## Transcript")
+    lines.append("")
     for message in messages:
         timestamp = message.created_at.strftime("%H:%M:%S")
         lines.append(f"**{message.role}** `{timestamp}`")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -169,3 +169,79 @@ def test_endless_mode_clamps_affection_inside_playable_range() -> None:
     assert session.affection_score <= 99
     session.apply_affection_delta(-80, "닥쳐 꺼져", source="reply")
     assert session.affection_score >= 1
+
+
+def test_yandere_jealousy_reliably_starts_difficult_situation() -> None:
+    persona = load_persona(Path("personas/yandere-special.json"))
+    session = ConversationSession(persona=persona)
+    starting_affection = session.affection_score
+
+    session.add_user_message("오늘 다른 여자 동기랑 저녁 먹고 왔어.")
+
+    assert session.difficult_situation is not None
+    assert session.difficult_situation.template_id == "jealous_other_person"
+    assert session.difficult_situation.active is True
+    assert session.mood.current == "sulky"
+    assert session.affection_score <= starting_affection - 5
+    assert "다른 사람 얘기" in session.prompt_context()["difficult_situation"]["title"]
+
+
+def test_difficult_situation_requires_multiple_repair_turns() -> None:
+    persona = load_persona(Path("personas/yandere-special.json"))
+    session = ConversationSession(persona=persona)
+    session.add_user_message("오늘 다른 여자 동기랑 저녁 먹고 왔어.")
+    score_after_trigger = session.affection_score
+
+    session.add_user_message("미안해, 네가 불안했겠다.")
+
+    assert session.difficult_situation is not None
+    assert session.difficult_situation.active is True
+    assert session.difficult_situation.user_turns == 1
+    assert session.difficult_situation.repair_score == 1
+    assert session.affection_score == score_after_trigger
+
+
+def test_difficult_situation_recovery_logs_repair_and_affection() -> None:
+    persona = load_persona(Path("personas/yandere-special.json"))
+    session = ConversationSession(persona=persona)
+    session.add_user_message("오늘 다른 여자 동기랑 저녁 먹고 왔어.")
+    score_after_trigger = session.affection_score
+
+    session.add_user_message("미안해, 네가 불안했겠다.")
+    session.add_user_message("앞으로 그런 약속은 먼저 말해줄게. 네 마음이 제일 중요해.")
+
+    assert session.difficult_situation is not None
+    assert session.difficult_situation.active is False
+    assert session.difficult_situation.outcome == "recovered"
+    assert session.affection_score >= score_after_trigger + 8
+    assert session.difficult_situation.resolution_summary
+    assert session.difficult_situation.resolution_summary in session.difficult_situation_history
+
+
+def test_difficult_situation_failure_penalizes_dismissive_handling() -> None:
+    persona = load_persona(Path("personas/wonyoung-idol.json"))
+    session = ConversationSession(persona=persona)
+    session.add_user_message("네 스케줄 약속 까먹었어.")
+    score_after_trigger = session.affection_score
+
+    session.add_user_message("됐어 별거 아니잖아.")
+
+    assert session.difficult_situation is not None
+    assert session.difficult_situation.active is False
+    assert session.difficult_situation.outcome == "failed"
+    assert session.affection_score <= score_after_trigger - 10
+
+
+def test_affection_report_includes_difficult_situation_outcome() -> None:
+    persona = load_persona(Path("personas/yandere-special.json"))
+    session = ConversationSession(persona=persona)
+
+    session.add_user_message("오늘 다른 여자 동기랑 저녁 먹고 왔어.")
+    session.add_user_message("미안해, 네가 불안했겠다.")
+    session.add_user_message("앞으로 그런 약속은 먼저 말해줄게. 네 마음이 제일 중요해.")
+
+    report = session.affection_report()
+
+    assert report["difficult_situations_total"] == 1
+    assert report["difficult_situations_recovered"] == 1
+    assert "어떻게 풀었는지" in report["difficult_situation_last"]

--- a/tests/test_personas.py
+++ b/tests/test_personas.py
@@ -19,3 +19,10 @@ def test_load_persona_validates_adult_and_nudges() -> None:
 
 def test_discover_personas_is_empty_for_missing_directory(tmp_path: Path) -> None:
     assert discover_personas(tmp_path / "missing") == []
+
+
+def test_load_persona_accepts_difficult_situation_overrides() -> None:
+    persona = load_persona(Path("personas/yandere-special.json"))
+
+    assert persona.difficult_situation_ids
+    assert "jealous_other_person" in persona.difficult_situation_ids

--- a/tests/test_session_io.py
+++ b/tests/test_session_io.py
@@ -74,6 +74,30 @@ def test_export_session_persists_relationship_state(tmp_path: Path) -> None:
     assert snapshot["summary"] == "서로의 일과 삶을 같이 책임지는 상태"
 
 
+def test_export_session_persists_difficult_situation_report(tmp_path: Path) -> None:
+    persona = load_persona(Path("personas/yandere-special.json"))
+    session = ConversationSession(persona=persona)
+    session.add_user_message("오늘 다른 여자 동기랑 저녁 먹고 왔어.")
+    session.add_user_message("미안해, 네가 불안했겠다.")
+    session.add_user_message("앞으로 그런 약속은 먼저 말해줄게. 네 마음이 제일 중요해.")
+
+    json_path, markdown_path = export_session(
+        session_dir=tmp_path,
+        persona=persona,
+        messages=session.messages,
+        relationship_state=session.export_state().get("relationship_state"),
+        difficult_situations=session.export_state().get("difficult_situations"),
+    )
+
+    payload = json_path.read_text(encoding="utf-8")
+    markdown = markdown_path.read_text(encoding="utf-8")
+
+    assert "difficult_situations" in payload
+    assert "어떻게 풀었는지" in payload
+    assert "## Difficult Situations" in markdown
+    assert "recovered" in markdown
+
+
 def test_slugify_keeps_ascii_safe_names() -> None:
     assert slugify("Han Seo Jin") == "han-seo-jin"
     assert slugify("유나") == "유나"


### PR DESCRIPTION
Closes #14

## Summary
- Adds difficult-situation traits to persona loading and runtime session context.
- Carries difficult-situation data through provider prompt hints and session export/load.
- Updates the yandere special persona to exercise the new difficult-situation behavior.
- Adds engine, persona, and session I/O coverage.

## Verification
- python3 -m pytest tests/test_engine.py tests/test_personas.py tests/test_session_io.py -q