### PR TITLE
fix: improve foreign persona localization UX

### DIFF
--- a/src/girlfriend_generator/app.py
+++ b/src/girlfriend_generator/app.py
@@ -1260,7 +1260,7 @@ def _finish_job(
             return None, previous_delivery, previous_status
 
         # ProviderReply now has parsed fields from LLM JSON
-        actual_text = reply.text  # already clean
+        actual_text = _with_translation_subtitle(reply.text, reply.translated_text)
         latest_user_text = next(
             (message.text for message in reversed(session.messages) if message.role == "user"),
             "",
@@ -1301,6 +1301,14 @@ def _finish_job(
         return None, delivery, "답장을 준비 중이에요."
 
     return None, previous_delivery, previous_status
+
+
+def _with_translation_subtitle(text: str, translated_text: str = "") -> str:
+    clean_text = (text or "").strip()
+    clean_translation = (translated_text or "").strip()
+    if not clean_translation or clean_translation == clean_text:
+        return clean_text
+    return f"{clean_text}\n({clean_translation})"
 
 
 def _handle_key(

--- a/src/girlfriend_generator/engine.py
+++ b/src/girlfriend_generator/engine.py
@@ -546,14 +546,15 @@ class ConversationSession:
 
     def _localized_greeting(self) -> str:
         language = get_language()
-        if language == "ko":
+        if language == self.persona.language:
             return self.persona.greeting
         mapping = {
             "en": f"hey, it's {self.persona.name}. wanted to text you first",
             "ja": f"ねえ、{self.persona.name}だよ。先に連絡してみた",
             "zh": f"喂，我是{self.persona.name}。我先来找你聊天了",
+            "ko": f"나 {self.persona.name}이야 먼저 톡해봤어",
         }
-        return mapping.get(language, mapping["en"])
+        return mapping.get(language, mapping["ko"])
 
     def tick(self, provider: object, now: datetime | None = None) -> TickResult:
         now = now or utc_now()

--- a/src/girlfriend_generator/models.py
+++ b/src/girlfriend_generator/models.py
@@ -97,6 +97,7 @@ class Persona:
     nudge_policy: NudgePolicy = field(default_factory=NudgePolicy)
     difficulty: str = "normal"  # easy, normal, hard, nightmare
     special_mode: str = ""  # "", "yandere"
+    language: str = "ko"
 
     def validate(self) -> None:
         if self.age < 20:
@@ -144,6 +145,7 @@ class ProviderReply:
     burst_messages: list[str] = field(default_factory=list)
     next_proactive_seconds: int | None = None
     photo_prompt: str = ""
+    translated_text: str = ""
 
 
 @dataclass(slots=True)

--- a/src/girlfriend_generator/personas.py
+++ b/src/girlfriend_generator/personas.py
@@ -88,6 +88,12 @@ def persona_from_pack(payload: dict[str, Any]) -> Persona:
         ),
         difficulty=payload.get("difficulty", "normal"),
         special_mode=payload.get("special_mode", ""),
+        language=str(
+            payload.get("language")
+            or payload.get("persona_language")
+            or payload.get("locale")
+            or "ko"
+        ),
     )
     persona.validate()
     return persona

--- a/src/girlfriend_generator/providers.py
+++ b/src/girlfriend_generator/providers.py
@@ -371,6 +371,7 @@ class OpenAIProvider:
             burst_messages=burst_list,
             next_proactive_seconds=proactive_s,
             photo_prompt=str(parsed.get("photo_prompt") or ""),
+            translated_text=str(parsed.get("translated_reply") or ""),
         )
 
     def generate_initiative(
@@ -506,6 +507,7 @@ class AnthropicProvider:
             coach_charm_type=str(parsed.get("user_charm_type", "")),
             coach_charm_feedback=str(parsed.get("user_charm_feedback", "")),
             photo_prompt=str(parsed.get("photo_prompt") or ""),
+            translated_text=str(parsed.get("translated_reply") or ""),
         )
 
     def generate_initiative(
@@ -663,6 +665,7 @@ def _build_system_prompt(
     nudge_ctx = ""
     if nudge_examples:
         nudge_ctx = f"Silence nudge examples for this stage: {' | '.join(nudge_examples[:3])}. "
+    subtitle_ctx = _foreign_subtitle_instructions(persona, language)
 
     return (
         f"너는 {persona.name}이라는 페르소나를 가진 AI 컴패니언이야. "
@@ -710,7 +713,7 @@ def _build_system_prompt(
         (f"\n=== SPECIAL MODE: {special_mode} ===\n" + _special_mode_instructions(special_mode) if special_mode else "") +
         "\nRESPONSE FORMAT — respond with ONLY valid JSON (no markdown, no explanation):\n"
         "{\n"
-        '  "reply": "your chat message in the target language",\n'
+        f"{subtitle_ctx}"
         '  "affection_delta": INTEGER — how their message made you feel. BE DRAMATIC:\n'
         "       +8 to +15: deeply touched (진심어린 고백, 세심한 배려, 특별한 순간)\n"
         "       +3 to +7: warm (장난+애정, 관심 표현, 재미있는 대화)\n"
@@ -834,6 +837,20 @@ def _language_instructions(language: str) -> str:
     return langs.get(language, langs["ko"]) + "\n"
 
 
+def _foreign_subtitle_instructions(persona: Persona, language: str) -> str:
+    persona_language = (persona.language or "ko").strip().lower()
+    target_language = (language or "ko").strip().lower()
+    if not persona_language or persona_language == target_language:
+        return (
+            '  "reply": "your chat message in the target language",\n'
+            '  "translated_reply": "",\n'
+        )
+    return (
+        f'  "reply": "your chat message in the persona language ({persona_language})",\n'
+        f'  "translated_reply": "natural translation of reply in the user language ({target_language})",\n'
+    )
+
+
 def _build_user_prompt(history: list[ChatMessage], user_text: str) -> str:
     transcript = "\n".join(f"{message.role}: {message.text}" for message in history[-8:])
     return f"Recent transcript:\n{transcript}\n\nLatest user text:\n{user_text}"
@@ -852,6 +869,7 @@ def parse_llm_json_response(text: str) -> dict:
         # Fallback: extract just the reply text
         return {
             "reply": text,
+            "translated_reply": "",
             "affection_delta": 0,
             "mood": "neutral",
             "memory_update": "",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,7 @@ from girlfriend_generator.app import (
     _show_scrollable_text_panel,
     _show_ending,
     _sync_provider_trace,
+    _with_translation_subtitle,
     run_chat_app,
 )
 from girlfriend_generator.engine import ConversationSession
@@ -122,6 +123,41 @@ def test_finish_job_turns_voice_transcript_into_reply_job() -> None:
     assert next_job.kind == "reply"
     assert next_delivery is None
     assert status == "voice transcript captured"
+
+
+def test_finish_job_adds_foreign_persona_translation_subtitle() -> None:
+    class PreviousJob:
+        kind = "reply"
+
+    persona = _load_test_persona()
+    session = ConversationSession(persona=persona)
+    session.bootstrap()
+    session.add_user_message("무슨 뜻이야?")
+
+    next_job, next_delivery, status = _finish_job(
+        session=session,
+        persona=persona,
+        provider=object(),
+        result=(True, ProviderReply(
+            text="je pensais a toi",
+            translated_text="네 생각하고 있었어",
+            typing_seconds=0.0,
+            trace_note="test",
+        )),
+        previous_job=PreviousJob(),
+        previous_delivery=None,
+        previous_status="assistant is thinking...",
+    )
+
+    assert next_job is None
+    assert next_delivery is not None
+    assert next_delivery.text == "je pensais a toi\n(네 생각하고 있었어)"
+    assert status == "답장을 준비 중이에요."
+
+
+def test_with_translation_subtitle_omits_empty_or_duplicate_translation() -> None:
+    assert _with_translation_subtitle("hello", "") == "hello"
+    assert _with_translation_subtitle("hello", "hello") == "hello"
 
 
 def test_export_command_writes_local_transcript_files(tmp_path: Path) -> None:

--- a/tests/test_personas.py
+++ b/tests/test_personas.py
@@ -15,6 +15,7 @@ def test_load_persona_validates_adult_and_nudges() -> None:
     assert persona.age >= 20
     assert persona.relationship_mode == "crush"
     assert persona.nudge_policy.templates
+    assert persona.language == "ko"
 
 
 def test_discover_personas_is_empty_for_missing_directory(tmp_path: Path) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -7,6 +7,8 @@ from girlfriend_generator.providers import (
     HeuristicProvider,
     OllamaProvider,
     OpenAIProvider,
+    _build_system_prompt,
+    parse_llm_json_response,
 )
 
 
@@ -143,3 +145,26 @@ def test_heuristic_provider_respects_non_korean_language() -> None:
     )
 
     assert any(token in reply.text.lower() for token in ["really", "cute", "listening", "attention"])
+
+
+def test_foreign_persona_prompt_requests_original_and_translated_reply() -> None:
+    persona = _load_test_persona()
+    persona.language = "fr"
+
+    prompt = _build_system_prompt(
+        persona=persona,
+        affection_score=50,
+        mood="neutral",
+        language="ko",
+    )
+
+    assert "persona language (fr)" in prompt
+    assert "user language (ko)" in prompt
+    assert '"translated_reply"' in prompt
+
+
+def test_parse_llm_json_response_keeps_translated_reply() -> None:
+    parsed = parse_llm_json_response('{"reply":"bonjour","translated_reply":"안녕"}')
+
+    assert parsed["reply"] == "bonjour"
+    assert parsed["translated_reply"] == "안녕"


### PR DESCRIPTION
Refs #20

## Summary
- Adds persona language metadata loading.
- Requests original-language replies plus translated_reply when persona language differs from configured user language.
- Renders translated subtitles below the original persona reply.
- Keeps configured-language greetings sensible when persona and UI language differ.

## Remaining #20 subitems
This PR addresses the foreign-persona translated subtitle slice of #20, but it does not claim all 14 required checklist items. Relationship progression, input clarity, report navigation, persona studio edit-list behavior, scene changes, and other checklist items still need separate evidence before #20 can close.

## Verification
- python3 -m pytest tests/test_app.py tests/test_personas.py tests/test_providers.py -q